### PR TITLE
validate reqID, check report is in period

### DIFF
--- a/chain/x/zoracle/handler.go
+++ b/chain/x/zoracle/handler.go
@@ -67,8 +67,19 @@ func handleMsgRequest(ctx sdk.Context, keeper Keeper, msg MsgRequest) sdk.Result
 }
 
 func handleMsgReport(ctx sdk.Context, keeper Keeper, msg MsgReport) sdk.Result {
-	// TODO: Check that requestID exists AND is in reporting period
+	// Validate sender
 	validators := keeper.StakingKeeper.GetLastValidators(ctx)
+
+	// check request id is valid.
+	request, err := keeper.GetRequest(ctx, msg.RequestID)
+	if err != nil {
+		return err.Result()
+	}
+
+	// check request is in period of reporting
+	if uint64(ctx.BlockHeight()) > request.ReportEndAt {
+		return types.ErrOutofReportPeriod(types.DefaultCodespace).Result()
+	}
 
 	isFound := false
 	for _, validator := range validators {

--- a/chain/x/zoracle/handler.go
+++ b/chain/x/zoracle/handler.go
@@ -75,7 +75,7 @@ func handleMsgReport(ctx sdk.Context, keeper Keeper, msg MsgReport) sdk.Result {
 
 	// check request is in period of reporting
 	if uint64(ctx.BlockHeight()) > request.ReportEndAt {
-		return types.ErrOutofReportPeriod(types.DefaultCodespace).Result()
+		return types.ErrOutOfReportPeriod(types.DefaultCodespace).Result()
 	}
 
 	// Validate sender

--- a/chain/x/zoracle/handler.go
+++ b/chain/x/zoracle/handler.go
@@ -67,9 +67,6 @@ func handleMsgRequest(ctx sdk.Context, keeper Keeper, msg MsgRequest) sdk.Result
 }
 
 func handleMsgReport(ctx sdk.Context, keeper Keeper, msg MsgReport) sdk.Result {
-	// Validate sender
-	validators := keeper.StakingKeeper.GetLastValidators(ctx)
-
 	// check request id is valid.
 	request, err := keeper.GetRequest(ctx, msg.RequestID)
 	if err != nil {
@@ -80,6 +77,9 @@ func handleMsgReport(ctx sdk.Context, keeper Keeper, msg MsgReport) sdk.Result {
 	if uint64(ctx.BlockHeight()) > request.ReportEndAt {
 		return types.ErrOutofReportPeriod(types.DefaultCodespace).Result()
 	}
+
+	// Validate sender
+	validators := keeper.StakingKeeper.GetLastValidators(ctx)
 
 	isFound := false
 	for _, validator := range validators {

--- a/chain/x/zoracle/handler_test.go
+++ b/chain/x/zoracle/handler_test.go
@@ -130,6 +130,17 @@ func TestReportInvalidValidator(t *testing.T) {
 	pubKey := keep.NewPubKey("0B485CFC0EECC619440448436F8FC9DF40566F2369E72400281454CB552AFB50")
 	validatorAddress := sdk.ValAddress(pubKey.Address())
 
+	// set request = 2
+	sender := sdk.AccAddress([]byte("sender"))
+	codeHash := keeper.SetCode(ctx, []byte("Code"), sender)
+	datapoint := types.NewDataPoint(1, codeHash, 3)
+	keeper.SetRequest(ctx, 1, datapoint)
+
+	// set pending
+	pendingRequests := keeper.GetPending(ctx)
+	pendingRequests = append(pendingRequests, 1)
+	keeper.SetPending(ctx, pendingRequests)
+
 	msg := types.NewMsgReport(1, []byte("data"), validatorAddress)
 	got := handleMsgReport(ctx, keeper, msg)
 	require.Equal(t, types.CodeInvalidValidator, got.Code)

--- a/chain/x/zoracle/handler_test.go
+++ b/chain/x/zoracle/handler_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tendermint/tendermint/libs/common"
 )
 
-func SetupTestValidator(ctx sdk.Context, keeper Keeper) sdk.ValAddress {
+func setupTestValidator(ctx sdk.Context, keeper Keeper) sdk.ValAddress {
 	pubKey := keep.NewPubKey("0B485CFC0EECC619440448436F8FC9DF40566F2369E72400281454CB552AFB50")
 	validatorAddress := sdk.ValAddress(pubKey.Address())
 	initTokens := sdk.TokensFromConsensusPower(10)
@@ -104,7 +104,7 @@ func TestRequestInvalidWasmCode(t *testing.T) {
 
 func TestReportSuccess(t *testing.T) {
 	ctx, keeper := keep.CreateTestInput(t, false)
-	validatorAddress := SetupTestValidator(ctx, keeper)
+	validatorAddress := setupTestValidator(ctx, keeper)
 
 	// set request = 2
 	sender := sdk.AccAddress([]byte("sender"))
@@ -152,7 +152,7 @@ func TestReportInvalidValidator(t *testing.T) {
 
 func TestOutOfReportPeriod(t *testing.T) {
 	ctx, keeper := keep.CreateTestInput(t, false)
-	validatorAddress := SetupTestValidator(ctx, keeper)
+	validatorAddress := setupTestValidator(ctx, keeper)
 
 	// set request = 2
 	sender := sdk.AccAddress([]byte("sender"))

--- a/chain/x/zoracle/handler_test.go
+++ b/chain/x/zoracle/handler_test.go
@@ -102,7 +102,22 @@ func TestReportSuccess(t *testing.T) {
 	updates := keeper.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	require.Equal(t, 1, len(updates))
 
-	msg := types.NewMsgReport(1, []byte("data"), validatorAddress)
+	// set request = 2
+	sender := sdk.AccAddress([]byte("sender"))
+	codeHash := keeper.SetCode(ctx, []byte("Code"), sender)
+	datapoint := types.NewDataPoint(2, codeHash, 3)
+	keeper.SetRequest(ctx, 2, datapoint)
+
+	// set pending
+	pendingRequests := keeper.GetPending(ctx)
+	pendingRequests = append(pendingRequests, 2)
+	keeper.SetPending(ctx, pendingRequests)
+
+	// set blockheight
+	ctx = ctx.WithBlockHeight(3)
+
+	// report data
+	msg := types.NewMsgReport(2, []byte("data"), validatorAddress)
 	got := handleMsgReport(ctx, keeper, msg)
 	require.True(t, got.IsOK(), "expected set report to be ok, got %v", got)
 

--- a/chain/x/zoracle/internal/types/error.go
+++ b/chain/x/zoracle/internal/types/error.go
@@ -8,11 +8,11 @@ import (
 const (
 	DefaultCodespace sdk.CodespaceType = ModuleName
 
-	CodeInvalidInput     sdk.CodeType = 101
-	CodeInvalidValidator sdk.CodeType = 102
-	CodeRequestNotFound  sdk.CodeType = 103
-	CodeInvalidOwner     sdk.CodeType = 104
-	CodeOutOf						 sdk.CodeType = 105
+	CodeInvalidInput     				sdk.CodeType = 101
+	CodeInvalidValidator 				sdk.CodeType = 102
+	CodeRequestNotFound  				sdk.CodeType = 103
+	CodeInvalidOwner     				sdk.CodeType = 104
+	CodeOutOfReportPeriod				sdk.CodeType = 105
 
 	WasmError sdk.CodeType = 105
 )
@@ -44,5 +44,5 @@ func ErrInvalidOwner(codespace sdk.CodespaceType) sdk.Error {
 }
 
 func ErrOutOfReportPeriod(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeOutOf, "report period already ended.")
+	return sdk.NewError(codespace, CodeOutOfReportPeriod, "report period already ended.")
 }

--- a/chain/x/zoracle/internal/types/error.go
+++ b/chain/x/zoracle/internal/types/error.go
@@ -12,6 +12,7 @@ const (
 	CodeInvalidValidator sdk.CodeType = 102
 	CodeRequestNotFound  sdk.CodeType = 103
 	CodeInvalidOwner     sdk.CodeType = 104
+	CodeOutOf						 sdk.CodeType = 105
 
 	WasmError sdk.CodeType = 105
 )
@@ -42,6 +43,6 @@ func ErrInvalidOwner(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidOwner, "invalid owner")
 }
 
-func ErrOutofReportPeriod(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeInvalidInput, "report period already ended.")
+func ErrOutOfReportPeriod(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeOutOf, "report period already ended.")
 }

--- a/chain/x/zoracle/internal/types/error.go
+++ b/chain/x/zoracle/internal/types/error.go
@@ -41,3 +41,7 @@ func ErrCodeAlreadyExisted(codespace sdk.CodespaceType) sdk.Error {
 func ErrInvalidOwner(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidOwner, "invalid owner")
 }
+
+func ErrOutofReportPeriod(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidInput, "report period already ended.")
+}


### PR DESCRIPTION
Fixes #65 
- add ErrOutofReportPeriod
- validate `reqID` in `handleMsgReport` function
- check `reqID` is in reporting period 

