### PR TITLE
scan: fix key warning on footer

### DIFF
--- a/scan/src/components/Footer.re
+++ b/scan/src/components/Footer.re
@@ -116,8 +116,8 @@ let make = () => {
             />
           </div>
         </Col>
-        {footerData->Belt_Array.map(((header, size, links)) =>
-           <Col size>
+        {footerData->Belt.Array.map(((header, size, links)) =>
+           <Col key=header size>
              {renderSubHeader(header)}
              {links->Belt.Array.map(((url, text)) => renderCommonLink(url, text)) |> React.array}
            </Col>


### PR DESCRIPTION
- change `Belt_Array` to `Belt.Array`
- fix key warning of rendering an array 