### PR TITLE
Add more data to request info endpoint

### DIFF
--- a/chain/cmd/bandsv/main.go
+++ b/chain/cmd/bandsv/main.go
@@ -41,8 +41,8 @@ type OracleRequestResp struct {
 }
 
 type OracleInfoResp struct {
-	Request zoracle.RequestWithReport `json:"request"`
-	Proof   Proof                     `json:"proof"`
+	Request zoracle.RequestInfo `json:"request"`
+	Proof   Proof               `json:"proof"`
 }
 
 type IAVLMerklePath struct {
@@ -416,7 +416,7 @@ func handleGetRequest(c *gin.Context) {
 		return
 	}
 
-	rwr := zoracle.RequestWithReport{}
+	var rwr zoracle.RequestInfo
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/zoracle/request/%d", requestId), nil)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/chain/x/zoracle/alias.go
+++ b/chain/x/zoracle/alias.go
@@ -37,10 +37,10 @@ var (
 )
 
 type (
-	Keeper            = keeper.Keeper
-	MsgRequest        = types.MsgRequest
-	MsgReport         = types.MsgReport
-	MsgStoreCode      = types.MsgStoreCode
-	MsgDeleteCode     = types.MsgDeleteCode
-	RequestWithReport = types.RequestWithReport
+	Keeper        = keeper.Keeper
+	MsgRequest    = types.MsgRequest
+	MsgReport     = types.MsgReport
+	MsgStoreCode  = types.MsgStoreCode
+	MsgDeleteCode = types.MsgDeleteCode
+	RequestInfo   = types.RequestInfo
 )

--- a/chain/x/zoracle/client/rest/query.go
+++ b/chain/x/zoracle/client/rest/query.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/http"
 
@@ -15,15 +16,87 @@ import (
 func getRequestHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		paramType := vars[requestID]
+		reqID := vars[requestID]
+		var request RequestQueryInfo
 
-		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/request/%s", storeName, paramType), nil)
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/request/%s", storeName, reqID), nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return
 		}
 
-		rest.PostProcessResponse(w, cliCtx, res)
+		var queryRequest types.RequestInfo
+		err = cliCtx.Codec.UnmarshalJSON(res, &queryRequest)
+
+		request.CodeHash = queryRequest.CodeHash
+		request.Params = queryRequest.Params
+		request.TargetBlock = int64(queryRequest.TargetBlock)
+		request.Result = queryRequest.Result
+
+		// Get request detail
+		searchRequest, err := utils.QueryTxsByEvents(
+			cliCtx,
+			[]string{fmt.Sprintf("%s.%s='%s'", types.EventTypeRequest, types.AttributeKeyRequestID, reqID)},
+			1,
+			1,
+		)
+
+		request.TxHash = searchRequest.Txs[0].TxHash
+		request.RequestAtHeight = searchRequest.Txs[0].Height
+		request.RequestAtTime = searchRequest.Txs[0].Timestamp
+		request.Requester = searchRequest.Txs[0].Tx.GetMsgs()[0].(types.MsgRequest).Sender
+		// Script detail
+		scriptInfoRaw, _, err := cliCtx.QueryWithData(
+			fmt.Sprintf(
+				"custom/%s/script/%s",
+				storeName,
+				hex.EncodeToString(queryRequest.CodeHash),
+			),
+			nil,
+		)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		err = cliCtx.Codec.UnmarshalJSON(scriptInfoRaw, &request.ScriptInfo)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		// Save report tx
+		reportTxs := make(map[string]ReportDetail)
+		searchReports, err := utils.QueryTxsByEvents(
+			cliCtx,
+			[]string{fmt.Sprintf("%s.%s='%s'", types.EventTypeReport, types.AttributeKeyRequestID, reqID)},
+			1,
+			30, // Estimated validator reports
+		)
+
+		for _, report := range searchReports.Txs {
+			reportTxs[report.Logs[0].Events[1].Attributes[1].Value] = ReportDetail{
+				TxHash:       report.TxHash,
+				ReportAtTime: report.Timestamp,
+			}
+		}
+
+		request.Reports = make([]ReportDetail, len(queryRequest.Reports))
+		for i, report := range queryRequest.Reports {
+			reportTx, ok := reportTxs[report.Validator.String()]
+			if !ok {
+				rest.WriteErrorResponse(w, http.StatusInternalServerError, "Cannot find report tx")
+				return
+			}
+			request.Reports[i] = ReportDetail{
+				Reporter:       report.Validator,
+				ReportAtHeight: int64(report.ReportAt),
+				TxHash:         reportTx.TxHash,
+				ReportAtTime:   reportTx.ReportAtTime,
+				Value:          report.Value,
+			}
+		}
+
+		rest.PostProcessResponse(w, cliCtx, request)
 	}
 }
 

--- a/chain/x/zoracle/client/rest/types.go
+++ b/chain/x/zoracle/client/rest/types.go
@@ -1,6 +1,9 @@
 package rest
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cmn "github.com/tendermint/tendermint/libs/common"
+
 	"github.com/bandprotocol/d3n/chain/x/zoracle/internal/types"
 )
 
@@ -9,4 +12,25 @@ type ScriptInfoWithTx struct {
 	TxHash          string           `json:"txhash"`
 	CreatedAtHeight int64            `json:"createdAtHeight"`
 	CreatedAtTime   string           `json:"createdAtTime"`
+}
+
+type ReportDetail struct {
+	Reporter       sdk.ValAddress `json:"reporter"`
+	TxHash         string         `json:"txhash"`
+	ReportAtHeight int64          `json:"reportAtHeight"`
+	ReportAtTime   string         `json:"reportAtTime"`
+	Value          types.RawJson  `json:"value"`
+}
+
+type RequestQueryInfo struct {
+	ScriptInfo      types.ScriptInfo `json:"scriptInfo"`
+	CodeHash        cmn.HexBytes     `json:"codeHash"`
+	Params          types.RawJson    `json:"params"`
+	TargetBlock     int64            `json:"targetBlock"`
+	Requester       sdk.AccAddress   `json:"requester"`
+	TxHash          string           `json:"txhash"`
+	RequestAtHeight int64            `json:"requestAtHeight"`
+	RequestAtTime   string           `json:"requestAtTime"`
+	Reports         []ReportDetail   `json:"reports"`
+	Result          []byte           `json:"result"`
 }

--- a/chain/x/zoracle/client/rest/types.go
+++ b/chain/x/zoracle/client/rest/types.go
@@ -15,22 +15,22 @@ type ScriptInfoWithTx struct {
 }
 
 type ReportDetail struct {
-	Reporter       sdk.ValAddress `json:"reporter"`
-	TxHash         string         `json:"txhash"`
-	ReportAtHeight int64          `json:"reportAtHeight"`
-	ReportAtTime   string         `json:"reportAtTime"`
-	Value          types.RawJson  `json:"value"`
+	Reporter         sdk.ValAddress `json:"reporter"`
+	TxHash           string         `json:"txhash"`
+	ReportedAtHeight int64          `json:"reportedAtHeight"`
+	ReportedAtTime   string         `json:"reportedAtTime"`
+	Value            types.RawJson  `json:"value"`
 }
 
 type RequestQueryInfo struct {
-	ScriptInfo      types.ScriptInfo `json:"scriptInfo"`
-	CodeHash        cmn.HexBytes     `json:"codeHash"`
-	Params          types.RawJson    `json:"params"`
-	TargetBlock     int64            `json:"targetBlock"`
-	Requester       sdk.AccAddress   `json:"requester"`
-	TxHash          string           `json:"txhash"`
-	RequestAtHeight int64            `json:"requestAtHeight"`
-	RequestAtTime   string           `json:"requestAtTime"`
-	Reports         []ReportDetail   `json:"reports"`
-	Result          []byte           `json:"result"`
+	ScriptInfo        types.ScriptInfo `json:"scriptInfo"`
+	CodeHash          cmn.HexBytes     `json:"codeHash"`
+	Params            types.RawJson    `json:"params"`
+	TargetBlock       int64            `json:"targetBlock"`
+	Requester         sdk.AccAddress   `json:"requester"`
+	TxHash            string           `json:"txhash"`
+	RequestedAtHeight int64            `json:"requestedAtHeight"`
+	RequestedAtTime   string           `json:"requestedAtTime"`
+	Reports           []ReportDetail   `json:"reports"`
+	Result            []byte           `json:"result"`
 }

--- a/chain/x/zoracle/internal/keeper/report.go
+++ b/chain/x/zoracle/internal/keeper/report.go
@@ -59,7 +59,7 @@ func (k Keeper) GetValidatorReports(ctx sdk.Context, requestID uint64) ([]types.
 		}
 		vReport := types.NewValidatorReport(
 			rawValue,
-			report.ReportAt,
+			report.ReportedAt,
 			types.GetValidatorAddress(iterator.Key(), types.ReportKeyPrefix, requestID),
 		)
 		data = append(data, vReport)

--- a/chain/x/zoracle/internal/types/querier.go
+++ b/chain/x/zoracle/internal/types/querier.go
@@ -20,47 +20,28 @@ func (u64a U64Array) String() string {
 	return fmt.Sprintf("%v", []uint64(u64a))
 }
 
-type ReportDetail struct {
-	Reporter sdk.AccAddress `json:"reporter"`
-	TxHash   string         `json:"txhash"`
-	ReportAt uint64         `json:"reportAt"`
-	Value    interface{}    `json:"value"`
+type RequestInfo struct {
+	CodeHash    []byte            `json:"codeHash"`
+	Params      RawJson           `json:"params"`
+	TargetBlock uint64            `json:"targetBlock"`
+	Reports     []ValidatorReport `json:"reports"`
+	Result      []byte            `json:"result"`
 }
 
-type RequestWithReport struct {
-	// Script
-	CodeHash    []byte         `json:"codeHash"`
-	Params      interface{}    `json:"params"`
-	TargetBlock uint64         `json:"targetBlock"`
-	Requester   sdk.AccAddress `json:"requester"`
-	RequestAt   uint64         `json:"requestAt"`
-	Reports     []ReportDetail `json:"reports"`
-	Result      []byte         `json:"result"`
-}
-
-func NewRequestWithReport(request Request, result []byte, reports []ValidatorReport) RequestWithReport {
-	return RequestWithReport{
-		Request: request,
-		Result:  result,
-		Reports: reports,
+func NewRequestInfo(
+	codeHash []byte,
+	params RawJson,
+	targetBlock uint64,
+	reports []ValidatorReport,
+	result []byte,
+) RequestInfo {
+	return RequestInfo{
+		CodeHash:    codeHash,
+		Params:      params,
+		TargetBlock: targetBlock,
+		Reports:     reports,
+		Result:      result,
 	}
-}
-
-func (re RequestWithReport) MarshalJSON() ([]byte, error) {
-	d, err := json.Marshal(re.Request)
-	if err != nil {
-		return nil, err
-	}
-
-	var data map[string]interface{}
-	if err := json.Unmarshal(d, &data); err != nil {
-		return nil, err
-	}
-
-	data["result"] = re.Result
-	data["reports"] = re.Reports
-
-	return json.Marshal(data)
 }
 
 type RawBytes []byte

--- a/chain/x/zoracle/internal/types/querier.go
+++ b/chain/x/zoracle/internal/types/querier.go
@@ -20,10 +20,22 @@ func (u64a U64Array) String() string {
 	return fmt.Sprintf("%v", []uint64(u64a))
 }
 
+type ReportDetail struct {
+	Reporter sdk.AccAddress `json:"reporter"`
+	TxHash   string         `json:"txhash"`
+	ReportAt uint64         `json:"reportAt"`
+	Value    interface{}    `json:"value"`
+}
+
 type RequestWithReport struct {
-	Request
-	Result  []byte            `json:"result"`
-	Reports []ValidatorReport `json:"reports"`
+	// Script
+	CodeHash    []byte         `json:"codeHash"`
+	Params      interface{}    `json:"params"`
+	TargetBlock uint64         `json:"targetBlock"`
+	Requester   sdk.AccAddress `json:"requester"`
+	RequestAt   uint64         `json:"requestAt"`
+	Reports     []ReportDetail `json:"reports"`
+	Result      []byte         `json:"result"`
 }
 
 func NewRequestWithReport(request Request, result []byte, reports []ValidatorReport) RequestWithReport {

--- a/chain/x/zoracle/internal/types/rawjson.go
+++ b/chain/x/zoracle/internal/types/rawjson.go
@@ -1,0 +1,12 @@
+package types
+
+type RawJson []byte
+
+func (j RawJson) MarshalJSON() ([]byte, error) {
+	return []byte(j), nil
+}
+
+func (j *RawJson) UnmarshalJSON(b []byte) error {
+	*j = RawJson(b)
+	return nil
+}

--- a/chain/x/zoracle/internal/types/report.go
+++ b/chain/x/zoracle/internal/types/report.go
@@ -6,30 +6,30 @@ import (
 
 // Report represent detail of validator report
 type Report struct {
-	Data     []byte `json:"data"`
-	ReportAt uint64 `json:"reportAt"`
+	Data       []byte `json:"data"`
+	ReportedAt uint64 `json:"reportedAt"`
 }
 
 // NewReport is a contructor of Report
-func NewReport(data []byte, reportAt uint64) Report {
+func NewReport(data []byte, reportedAt uint64) Report {
 	return Report{
-		Data:     data,
-		ReportAt: reportAt,
+		Data:       data,
+		ReportedAt: reportedAt,
 	}
 }
 
 // ValidatorReport is a report that contain operator address in struct
 type ValidatorReport struct {
-	Value     RawJson        `json:"value"`
-	ReportAt  uint64         `json:"reportAt"`
-	Validator sdk.ValAddress `json:"validator"`
+	Value      RawJson        `json:"value"`
+	ReportedAt uint64         `json:"reportedAt"`
+	Validator  sdk.ValAddress `json:"validator"`
 }
 
 // NewValidatorReport is a contructor of ValidatorReport
-func NewValidatorReport(value RawJson, reportAt uint64, valAddress sdk.ValAddress) ValidatorReport {
+func NewValidatorReport(value RawJson, reportedAt uint64, valAddress sdk.ValAddress) ValidatorReport {
 	return ValidatorReport{
-		Value:     value,
-		ReportAt:  reportAt,
-		Validator: valAddress,
+		Value:      value,
+		ReportedAt: reportedAt,
+		Validator:  valAddress,
 	}
 }

--- a/chain/x/zoracle/internal/types/report.go
+++ b/chain/x/zoracle/internal/types/report.go
@@ -20,14 +20,16 @@ func NewReport(data []byte, reportAt uint64) Report {
 
 // ValidatorReport is a report that contain operator address in struct
 type ValidatorReport struct {
-	Report
-	Validator string `json:"validator"`
+	Value     RawJson        `json:"value"`
+	ReportAt  uint64         `json:"reportAt"`
+	Validator sdk.ValAddress `json:"validator"`
 }
 
 // NewValidatorReport is a contructor of ValidatorReport
-func NewValidatorReport(report Report, valAddress sdk.ValAddress) ValidatorReport {
+func NewValidatorReport(value RawJson, reportAt uint64, valAddress sdk.ValAddress) ValidatorReport {
 	return ValidatorReport{
-		Report:    report,
-		Validator: valAddress.String(),
+		Value:     value,
+		ReportAt:  reportAt,
+		Validator: valAddress,
 	}
 }


### PR DESCRIPTION
fixed #156 

- Change `ValidatorReport` struct to store parsed report value
- Add `RequestInfo` struct in `types/querrier.go` to store temporary value from store
- Last result from this endpoint `http://localhost:1317/zoracle/request/2`
```
{
  "height": "0",
  "result": {
    "scriptInfo": {
      "name": "Crypto price",
      "params": [
        {
          "name": "symbol_cg",
          "type": "String"
        },
        {
          "name": "symbol_cc",
          "type": "String"
        }
      ],
      "dataSources": [
        {
          "name": "coin_gecko",
          "type": "f32"
        },
        {
          "name": "crypto_compare",
          "type": "f32"
        }
      ],
      "creator": "band1r8u4m0wefrdyp7sdde7drtrt94qczggkv38jrk"
    },
    "codeHash": "33CEFD052EB9B0CDA3D38D4D87313295E45FDA5C5B0D6AB9E54870866F62FC80",
    "params": {
      "symbol_cg": "ethereum",
      "symbol_cc": "ETH"
    },
    "targetBlock": "16",
    "requester": "band1r8u4m0wefrdyp7sdde7drtrt94qczggkv38jrk",
    "txhash": "73502FD55D23D704AEB5182BA54F04513AB45F629C0BEEE3B2259E03249803C0",
    "requestAtHeight": "12",
    "requestAtTime": "2020-01-13T10:24:28Z",
    "reports": [
      {
        "reporter": "bandvaloper1zpmsn2vg2zcrx4jlg49t2f2y2cwjykr6jnmyxv",
        "txhash": "4FC7750278256DE5FADA00B65732CB2E4DD2C61016126853BBD22EA6C0D02A51",
        "reportAtHeight": "13",
        "reportAtTime": "2020-01-13T10:24:33Z",
        "value": {
          "coin_gecko": 143.35,
          "crypto_compare": 143.59
        }
      },
      {
        "reporter": "bandvaloper1r8u4m0wefrdyp7sdde7drtrt94qczggkq8r3xa",
        "txhash": "E415D95308CD3BDA8ACF834DB27530D90B02CFB7E3D346E820B2A3ED9BA2A373",
        "reportAtHeight": "13",
        "reportAtTime": "2020-01-13T10:24:33Z",
        "value": {
          "coin_gecko": 143.35,
          "crypto_compare": 143.59
        }
      },
      {
        "reporter": "bandvaloper1fwffdxysc5a0hu0falsq4lyneucj05cwryzfp0",
        "txhash": "626A66DCA50DC60BA4837185E442DE7638D4E1999AC59364C3396D10196EC590",
        "reportAtHeight": "13",
        "reportAtTime": "2020-01-13T10:24:33Z",
        "value": {
          "coin_gecko": 143.35,
          "crypto_compare": 143.59
        }
      },
      {
        "reporter": "bandvaloper13zmknvkq2sj920spz90g4r9zjan8g58423y76e",
        "txhash": "2B9F252B812F2A3B14B129253E4F89A9E29FB1A66B0447AC51A06D3A99DE6A49",
        "reportAtHeight": "13",
        "reportAtTime": "2020-01-13T10:24:33Z",
        "value": {
          "coin_gecko": 143.35,
          "crypto_compare": 143.59
        }
      }
    ],
    "result": "AAAAAAAAOAs="
  }
}
```