### PR TITLE
Emit script name during zoracle transactions

### DIFF
--- a/chain/cmd/request/main.go
+++ b/chain/cmd/request/main.go
@@ -63,7 +63,7 @@ func main() {
 	// }, flags.BroadcastBlock))
 
 	// Send transaction to store code first (commend it if already stored code)
-	fmt.Println(tx.SendTransaction(zoracle.NewMsgStoreCode(bytes, tx.Sender()), flags.BroadcastBlock))
+	fmt.Println(tx.SendTransaction(zoracle.NewMsgStoreCode(bytes, "Crypto price", tx.Sender()), flags.BroadcastBlock))
 
 	codeHash, _ := hex.DecodeString("33cefd052eb9b0cda3d38d4d87313295e45fda5c5b0d6ab9e54870866f62fc80")
 

--- a/chain/cmd/request/main.go
+++ b/chain/cmd/request/main.go
@@ -65,7 +65,7 @@ func main() {
 	// Send transaction to store code first (commend it if already stored code)
 	fmt.Println(tx.SendTransaction(zoracle.NewMsgStoreCode(bytes, "Crypto price", tx.Sender()), flags.BroadcastBlock))
 
-	codeHash, _ := hex.DecodeString("33cefd052eb9b0cda3d38d4d87313295e45fda5c5b0d6ab9e54870866f62fc80")
+	codeHash, _ := hex.DecodeString("089a092741d2bbe10b1cfaa8e48d1512a51ef183e579ae29f89af59db3e72c85")
 
 	// BTC parameter
 	params, _ := hex.DecodeString("0000000000000007626974636f696e0000000000000003425443")

--- a/chain/wasm/wasm.go
+++ b/chain/wasm/wasm.go
@@ -3,7 +3,6 @@ package wasm
 import (
 	"encoding/binary"
 	"errors"
-	"unicode"
 
 	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 )
@@ -59,32 +58,6 @@ func parseOutput(instance wasm.Instance, ptr int64) ([]byte, error) {
 
 func storeParams(instance wasm.Instance, params []byte) (int64, error) {
 	return allocateInner(instance, params)
-}
-
-func Name(code []byte) (string, error) {
-	instance, err := wasm.NewInstance(code)
-	if err != nil {
-		return "", err
-	}
-	defer instance.Close()
-	fn := instance.Exports["__name"]
-	if fn == nil {
-		return "", errors.New("__name not implemented")
-	}
-	ptr, err := fn()
-	if err != nil {
-		return "", err
-	}
-	rawResult, err := parseOutput(instance, ptr.ToI64())
-	if err != nil {
-		return "", err
-	}
-	for _, ch := range string(rawResult) {
-		if !unicode.IsPrint(ch) {
-			return "", errors.New("Invalid name character")
-		}
-	}
-	return string(rawResult), nil
 }
 
 func ParamsInfo(code []byte) ([]byte, error) {

--- a/chain/wasm/wasm_test.go
+++ b/chain/wasm/wasm_test.go
@@ -38,12 +38,6 @@ func loadWasmFile() ([]byte, wasm.Instance) {
 	}
 	return bytes, instance
 }
-func TestName(t *testing.T) {
-	code, _ := loadWasmFile()
-	name, err := Name(code)
-	require.Nil(t, err)
-	require.Equal(t, "Crypto price", name)
-}
 
 func TestParamsInfo(t *testing.T) {
 	code, _ := loadWasmFile()

--- a/chain/x/zoracle/alias.go
+++ b/chain/x/zoracle/alias.go
@@ -18,6 +18,7 @@ const (
 	AttributeKeyPrepare      = types.AttributeKeyPrepare
 	AttributeKeyResult       = types.AttributeKeyResult
 	AttributeKeyValidator    = types.AttributeKeyValidator
+	AttributeKeyCodeName     = types.AttributeKeyCodeName
 )
 
 var (

--- a/chain/x/zoracle/client/cli/tx.go
+++ b/chain/x/zoracle/client/cli/tx.go
@@ -102,19 +102,19 @@ func GetCmdReport(cdc *codec.Codec) *cobra.Command {
 // GetCmdStoreCode implements the store code command handler
 func GetCmdStoreCode(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "store [code]",
+		Use:   "store [name] [code]",
 		Short: "store wasm code to chain",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			code, err := hex.DecodeString(args[0])
+			code, err := hex.DecodeString(args[1])
 			if err != nil {
 				return err
 			}
 
-			msg := types.NewMsgStoreCode(code, cliCtx.GetFromAddress())
+			msg := types.NewMsgStoreCode(code, args[0], cliCtx.GetFromAddress())
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/chain/x/zoracle/client/rest/query.go
+++ b/chain/x/zoracle/client/rest/query.go
@@ -76,7 +76,7 @@ func getRequestHandler(cliCtx context.CLIContext, storeName string) http.Handler
 
 		for _, report := range searchReports.Txs {
 			// TODO: Find validator address from tx not assume in first log of tx
-			reportTxs[report.Logs[0].Events[1].Attributes[1].Value] = ReportDetail{
+			reportTxs[report.Logs[0].Events[1].Attributes[2].Value] = ReportDetail{
 				TxHash:         report.TxHash,
 				ReportedAtTime: report.Timestamp,
 			}

--- a/chain/x/zoracle/handler_test.go
+++ b/chain/x/zoracle/handler_test.go
@@ -68,12 +68,17 @@ func TestRequestSuccess(t *testing.T) {
 		Key:   []byte(types.AttributeKeyCodeHash),
 		Value: []byte(hex.EncodeToString(codeHash)),
 	}
+	namePair := common.KVPair{
+		Key:   []byte(types.AttributeKeyCodeName),
+		Value: []byte("Crypto price"),
+	}
 	preparePair := common.KVPair{
 		Key:   []byte(types.AttributeKeyPrepare),
 		Value: []byte("5b7b22636d64223a226375726c222c2261726773223a5b2268747470733a2f2f6170692e636f696e6765636b6f2e636f6d2f6170692f76332f73696d706c652f70726963653f6964733d626974636f696e2676735f63757272656e636965733d757364225d7d2c7b22636d64223a226375726c222c2261726773223a5b2268747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d425443267473796d733d555344225d7d5d"),
 	}
 	require.Equal(t, codeHashPair, ctx.EventManager().Events()[0].Attributes[1])
-	require.Equal(t, preparePair, ctx.EventManager().Events()[0].Attributes[2])
+	require.Equal(t, namePair, ctx.EventManager().Events()[0].Attributes[2])
+	require.Equal(t, preparePair, ctx.EventManager().Events()[0].Attributes[3])
 }
 
 func TestRequestInvalidCodeHash(t *testing.T) {
@@ -104,9 +109,10 @@ func TestReportSuccess(t *testing.T) {
 	validatorAddress := setupTestValidator(ctx, keeper)
 
 	// set request = 2
+	name := "Script1"
 	sender := sdk.AccAddress([]byte("sender"))
 	codeHash := keeper.SetCode(ctx, []byte("Code"), sender)
-	request := types.NewRequest(codeHash, []byte("params"), 3)
+	request := types.NewRequest(name, codeHash, []byte("params"), 3)
 	keeper.SetRequest(ctx, 2, request)
 
 	// set pending
@@ -132,9 +138,10 @@ func TestReportInvalidValidator(t *testing.T) {
 	validatorAddress := sdk.ValAddress(pubKey.Address())
 
 	// set request = 2
+	name := "Script1"
 	sender := sdk.AccAddress([]byte("sender"))
 	codeHash := keeper.SetCode(ctx, []byte("Code"), sender)
-	request := types.NewRequest(codeHash, []byte("params"), 3)
+	request := types.NewRequest(name, codeHash, []byte("params"), 3)
 	keeper.SetRequest(ctx, 1, request)
 
 	// set pending
@@ -152,9 +159,10 @@ func TestOutOfReportPeriod(t *testing.T) {
 	validatorAddress := setupTestValidator(ctx, keeper)
 
 	// set request = 2
+	name := "Script1"
 	sender := sdk.AccAddress([]byte("sender"))
 	codeHash := keeper.SetCode(ctx, []byte("Code"), sender)
-	request := types.NewRequest(codeHash, []byte("params"), 3)
+	request := types.NewRequest(name, codeHash, []byte("params"), 3)
 	keeper.SetRequest(ctx, 2, request)
 
 	// set pending
@@ -267,12 +275,13 @@ func TestEndBlock(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
+	name := "Script1"
 	sender := sdk.AccAddress([]byte("sender"))
 	codeHash := keeper.SetCode(ctx, code, sender)
 
 	params, _ := hex.DecodeString("0000000000000007626974636f696e0000000000000003425443")
 	// set request
-	request := types.NewRequest(codeHash, params, 3)
+	request := types.NewRequest(name, codeHash, params, 3)
 	keeper.SetRequest(ctx, 1, request)
 
 	// set pending

--- a/chain/x/zoracle/internal/keeper/code.go
+++ b/chain/x/zoracle/internal/keeper/code.go
@@ -7,9 +7,9 @@ import (
 )
 
 // SetCode is a function to save codeHash as key and code as value.
-func (k Keeper) SetCode(ctx sdk.Context, code []byte, owner sdk.AccAddress) []byte {
+func (k Keeper) SetCode(ctx sdk.Context, code []byte, name string, owner sdk.AccAddress) []byte {
 	store := ctx.KVStore(k.storeKey)
-	sc := types.NewStoredCode(code, owner)
+	sc := types.NewStoredCode(code, name, owner)
 	codeHash := sc.GetCodeHash()
 	key := types.CodeHashStoreKey(codeHash)
 	store.Set(key, k.cdc.MustMarshalBinaryBare(sc))

--- a/chain/x/zoracle/internal/keeper/code_test.go
+++ b/chain/x/zoracle/internal/keeper/code_test.go
@@ -46,18 +46,19 @@ func TestDeleteCode(t *testing.T) {
 
 func TestGetCodesIterator(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	owner := sdk.AccAddress([]byte("owner"))
 
+	owner := sdk.AccAddress([]byte("owner"))
+	names := []string{"script1", "script2"}
 	codes := [][]byte{[]byte("This is code"), []byte("This is code2")}
 
-	for _, code := range codes {
-		keeper.SetCode(ctx, code, owner)
+	for i, _ := range codes {
+		keeper.SetCode(ctx, codes[i], names[i], owner)
 	}
 
 	iterator := keeper.GetCodesIterator(ctx)
 	i := 0
 	for ; iterator.Valid(); iterator.Next() {
-		require.Equal(t, types.NewStoredCode(codes[i], owner).GetCodeHash(), iterator.Key()[1:])
+		require.Equal(t, types.NewStoredCode(codes[i], names[i], owner).GetCodeHash(), iterator.Key()[1:])
 		i++
 	}
 	require.Equal(t, len(codes), i)

--- a/chain/x/zoracle/internal/keeper/code_test.go
+++ b/chain/x/zoracle/internal/keeper/code_test.go
@@ -10,16 +10,16 @@ import (
 
 func TestGetterSetterCode(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-
+	name := "script"
 	owner := sdk.AccAddress([]byte("owner"))
 
 	code := []byte("This is code")
-	codeHash := types.NewStoredCode(code, owner).GetCodeHash()
+	codeHash := types.NewStoredCode(code, name, owner).GetCodeHash()
 
 	_, err := keeper.GetCode(ctx, codeHash)
 	require.NotNil(t, err)
 
-	actualCodeHash := keeper.SetCode(ctx, code, owner)
+	actualCodeHash := keeper.SetCode(ctx, code, name, owner)
 	storedCode, err := keeper.GetCode(ctx, actualCodeHash)
 	require.Nil(t, err)
 	require.Equal(t, code, storedCode.Code)
@@ -33,9 +33,10 @@ func TestDeleteCode(t *testing.T) {
 	owner := sdk.AccAddress([]byte("owner"))
 
 	code := []byte("This is code")
-	codeHash := types.NewStoredCode(code, owner).GetCodeHash()
+	name := "script"
+	codeHash := types.NewStoredCode(code, name, owner).GetCodeHash()
 
-	keeper.SetCode(ctx, code, owner)
+	keeper.SetCode(ctx, code, name, owner)
 
 	keeper.DeleteCode(ctx, codeHash)
 	_, err := keeper.GetCode(ctx, codeHash)

--- a/chain/x/zoracle/internal/keeper/querier.go
+++ b/chain/x/zoracle/internal/keeper/querier.go
@@ -96,12 +96,6 @@ func queryScript(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 	if err != nil {
 		panic("cannot get codehash")
 	}
-	// Get name
-	name, err := wasm.Name(code.Code)
-	if err != nil {
-		// TODO: Return err
-		name = ""
-	}
 
 	// Get raw params info
 	rawParamsInfo, err := wasm.ParamsInfo(code.Code)

--- a/chain/x/zoracle/internal/keeper/querier.go
+++ b/chain/x/zoracle/internal/keeper/querier.go
@@ -121,7 +121,7 @@ func queryScript(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 		}
 	}
 
-	return codec.MustMarshalJSONIndent(keeper.cdc, types.NewScriptInfo(name, codeHash, paramsInfo, dataInfo, code.Owner)), nil
+	return codec.MustMarshalJSONIndent(keeper.cdc, types.NewScriptInfo(code.Name, codeHash, paramsInfo, dataInfo, code.Owner)), nil
 }
 
 func queryAllScripts(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
@@ -160,5 +160,4 @@ func queryAllScripts(ctx sdk.Context, path []string, req abci.RequestQuery, keep
 		i++
 	}
 	return codec.MustMarshalJSONIndent(keeper.cdc, results), nil
-
 }

--- a/chain/x/zoracle/internal/keeper/querier_test.go
+++ b/chain/x/zoracle/internal/keeper/querier_test.go
@@ -36,7 +36,8 @@ func TestQueryRequestById(t *testing.T) {
 	params, _ := hex.DecodeString("0000000000000007626974636f696e0000000000000003425443")
 
 	// set request
-	request := types.NewRequest(codeHash, params, 3)
+	name := "Crypto Price"
+	request := types.NewRequest(name, codeHash, params, 3)
 	keeper.SetRequest(ctx, 1, request)
 	result := []byte("result")
 	keeper.SetResult(ctx, 1, codeHash, params, result)
@@ -52,7 +53,7 @@ func TestQueryRequestById(t *testing.T) {
 	paramsMap := []byte(`{"symbol_cg":"bitcoin","symbol_cc":"BTC"}`)
 
 	// Use bytes format for comparison
-	request = types.NewRequest(codeHash, params, 3)
+	request = types.NewRequest(name, codeHash, params, 3)
 	acs, errJSON := codec.MarshalJSONIndent(
 		keeper.cdc,
 		types.NewRequestInfo(
@@ -86,10 +87,11 @@ func TestQueryPendingRequest(t *testing.T) {
 	require.Equal(t, acs, acsBytes)
 
 	// set request
+	name := "Crypto price"
 	owner := sdk.AccAddress([]byte("owner"))
 	code := []byte("code")
 	codeHash := keeper.SetCode(ctx, code, owner)
-	request := types.NewRequest(codeHash, []byte("params"), 3)
+	request := types.NewRequest(name, codeHash, []byte("params"), 3)
 	keeper.SetRequest(ctx, 2, request)
 
 	// set pending

--- a/chain/x/zoracle/internal/keeper/querier_test.go
+++ b/chain/x/zoracle/internal/keeper/querier_test.go
@@ -32,12 +32,13 @@ func TestQueryRequestById(t *testing.T) {
 	absPath, _ := filepath.Abs("../../../../wasm/res/test_u64.wasm")
 	code, _ := wasm.ReadBytes(absPath)
 	owner := sdk.AccAddress([]byte("owner"))
-	codeHash := keeper.SetCode(ctx, code, owner)
+	name := "Crypto Price"
+	codeHash := keeper.SetCode(ctx, code, name, owner)
 	params, _ := hex.DecodeString("0000000000000007626974636f696e0000000000000003425443")
 
 	// set request
-	name := "Crypto Price"
-	request := types.NewRequest(name, codeHash, params, 3)
+
+	request := types.NewRequest(codeHash, params, 3)
 	keeper.SetRequest(ctx, 1, request)
 	result := []byte("result")
 	keeper.SetResult(ctx, 1, codeHash, params, result)
@@ -53,7 +54,7 @@ func TestQueryRequestById(t *testing.T) {
 	paramsMap := []byte(`{"symbol_cg":"bitcoin","symbol_cc":"BTC"}`)
 
 	// Use bytes format for comparison
-	request = types.NewRequest(name, codeHash, params, 3)
+	request = types.NewRequest(codeHash, params, 3)
 	acs, errJSON := codec.MarshalJSONIndent(
 		keeper.cdc,
 		types.NewRequestInfo(
@@ -90,8 +91,8 @@ func TestQueryPendingRequest(t *testing.T) {
 	name := "Crypto price"
 	owner := sdk.AccAddress([]byte("owner"))
 	code := []byte("code")
-	codeHash := keeper.SetCode(ctx, code, owner)
-	request := types.NewRequest(name, codeHash, []byte("params"), 3)
+	codeHash := keeper.SetCode(ctx, code, name, owner)
+	request := types.NewRequest(codeHash, []byte("params"), 3)
 	keeper.SetRequest(ctx, 2, request)
 
 	// set pending

--- a/chain/x/zoracle/internal/keeper/request_test.go
+++ b/chain/x/zoracle/internal/keeper/request_test.go
@@ -13,7 +13,7 @@ func TestGetterSetterRequest(t *testing.T) {
 	_, err := keeper.GetRequest(ctx, 1)
 	require.NotNil(t, err)
 
-	request := types.NewRequest("Script name", []byte("CodeHash"), []byte("params"), 10)
+	request := types.NewRequest([]byte("CodeHash"), []byte("params"), 10)
 
 	keeper.SetRequest(ctx, 1, request)
 	actualRequest, err := keeper.GetRequest(ctx, 1)

--- a/chain/x/zoracle/internal/keeper/request_test.go
+++ b/chain/x/zoracle/internal/keeper/request_test.go
@@ -13,7 +13,7 @@ func TestGetterSetterRequest(t *testing.T) {
 	_, err := keeper.GetRequest(ctx, 1)
 	require.NotNil(t, err)
 
-	request := types.NewRequest([]byte("CodeHash"), []byte("params"), 10)
+	request := types.NewRequest("Script name", []byte("CodeHash"), []byte("params"), 10)
 
 	keeper.SetRequest(ctx, 1, request)
 	actualRequest, err := keeper.GetRequest(ctx, 1)

--- a/chain/x/zoracle/internal/types/code.go
+++ b/chain/x/zoracle/internal/types/code.go
@@ -8,18 +8,21 @@ import (
 // StoredCode store actual code with owner
 type StoredCode struct {
 	Code  []byte
+	Name  string
 	Owner sdk.AccAddress
 }
 
 // NewStoredCode is a constructor of StoredCode
-func NewStoredCode(code []byte, owner sdk.AccAddress) StoredCode {
+func NewStoredCode(code []byte, name string, owner sdk.AccAddress) StoredCode {
 	return StoredCode{
 		Code:  code,
+		Name:  name,
 		Owner: owner,
 	}
 }
 
 // GetCodeHash is a function to calculate hash of actual code
 func (c StoredCode) GetCodeHash() []byte {
-	return crypto.Sha256(c.Code)
+	// TODO: Scheme to calculate codehash
+	return crypto.Sha256(append([]byte(c.Name), c.Code...))
 }

--- a/chain/x/zoracle/internal/types/code_test.go
+++ b/chain/x/zoracle/internal/types/code_test.go
@@ -9,10 +9,12 @@ import (
 )
 
 func TestGetCodeHash(t *testing.T) {
-
 	code := []byte("This is code")
-	expectedCodeHash, _ := hex.DecodeString("15e0082d52b1a8fd85ce99ae62d1b0ac236709d4ae3ab7554bba52931231bd8a")
-	sc := NewStoredCode(code, sdk.AccAddress("owner"))
+	expectedCodeHash1, _ := hex.DecodeString("9a794cce93b8fa9b2477f1498bc63f1b602b2dd8edd06747183298822183e935")
+	expectedCodeHash2, _ := hex.DecodeString("3619be5b7c53a74dec4d0ca50825681accd4c9ed7471538b2d1438794bf1cd4c")
+	sc1 := NewStoredCode(code, "script1", sdk.AccAddress("owner"))
+	sc2 := NewStoredCode(code, "script2", sdk.AccAddress("owner"))
 
-	require.Equal(t, expectedCodeHash, sc.GetCodeHash())
+	require.Equal(t, expectedCodeHash1, sc1.GetCodeHash())
+	require.Equal(t, expectedCodeHash2, sc2.GetCodeHash())
 }

--- a/chain/x/zoracle/internal/types/events.go
+++ b/chain/x/zoracle/internal/types/events.go
@@ -12,4 +12,5 @@ const (
 	AttributeKeyPrepare      = "prepare"
 	AttributeKeyResult       = "result"
 	AttributeKeyValidator    = "validator"
+	AttributeKeyCodeName     = "code_name"
 )

--- a/chain/x/zoracle/internal/types/msgs.go
+++ b/chain/x/zoracle/internal/types/msgs.go
@@ -114,16 +114,19 @@ func (msg MsgReport) GetSignBytes() []byte {
 // MsgStoreCode defines a Code and owner of this
 type MsgStoreCode struct {
 	Code  []byte         `json:"code"`
+	Name  string         `json:"name"`
 	Owner sdk.AccAddress `json:"owner"`
 }
 
 // NewMsgStoreCode is a constructor function for MsgReport
 func NewMsgStoreCode(
 	code []byte,
+	name string,
 	owner sdk.AccAddress,
 ) MsgStoreCode {
 	return MsgStoreCode{
 		Code:  code,
+		Name:  name,
 		Owner: owner,
 	}
 }
@@ -139,7 +142,9 @@ func (msg MsgStoreCode) ValidateBasic() sdk.Error {
 	if msg.Owner.Empty() {
 		return sdk.ErrInvalidAddress(msg.Owner.String())
 	}
-
+	if len(msg.Name) == 0 {
+		return sdk.ErrUnknownRequest("Name must not be empty")
+	}
 	if msg.Code == nil || len(msg.Code) == 0 {
 		return sdk.ErrUnknownRequest("Code must not be empty")
 	}

--- a/chain/x/zoracle/internal/types/msgs_test.go
+++ b/chain/x/zoracle/internal/types/msgs_test.go
@@ -106,7 +106,8 @@ func TestMsgReportGetSignBytes(t *testing.T) {
 
 func TestMsgStoreCode(t *testing.T) {
 	owner, _ := sdk.AccAddressFromHex("b80f2a5df7d5710b15622d1a9f1e3830ded5bda8")
-	msg := NewMsgStoreCode([]byte("Code"), owner)
+	name := "script name"
+	msg := NewMsgStoreCode([]byte("Code"), name, owner)
 
 	require.Equal(t, RouterKey, msg.Route())
 	require.Equal(t, "store", msg.Type())
@@ -114,17 +115,19 @@ func TestMsgStoreCode(t *testing.T) {
 
 func TestMsgStoreCodeValidation(t *testing.T) {
 	code := []byte("Code")
+	name := "script name"
 	owner, _ := sdk.AccAddressFromHex("b80f2a5df7d5710b15622d1a9f1e3830ded5bda8")
 	failOwner, _ := sdk.AccAddressFromHex("")
 	cases := []struct {
 		valid bool
 		tx    MsgStoreCode
 	}{
-		{true, NewMsgStoreCode(code, owner)},
-		{false, NewMsgStoreCode([]byte(""), owner)},
-		{false, NewMsgStoreCode(nil, owner)},
-		{false, NewMsgStoreCode(code, failOwner)},
-		{false, NewMsgStoreCode(code, nil)},
+		{true, NewMsgStoreCode(code, name, owner)},
+		{false, NewMsgStoreCode([]byte(""), name, owner)},
+		{false, NewMsgStoreCode(code, "", owner)},
+		{false, NewMsgStoreCode(nil, name, owner)},
+		{false, NewMsgStoreCode(code, name, failOwner)},
+		{false, NewMsgStoreCode(code, name, nil)},
 	}
 
 	for _, tc := range cases {
@@ -141,12 +144,13 @@ func TestMsgStoreCodeGetSignBytes(t *testing.T) {
 	config := sdk.GetConfig()
 	config.SetBech32PrefixForAccount("band", "band"+sdk.PrefixPublic)
 
+	name := "script name"
 	code := []byte("Code")
 	owner, _ := sdk.AccAddressFromHex("b80f2a5df7d5710b15622d1a9f1e3830ded5bda8")
-	msg := NewMsgStoreCode(code, owner)
+	msg := NewMsgStoreCode(code, name, owner)
 	res := msg.GetSignBytes()
 
-	expected := `{"type":"zoracle/Store","value":{"code":"Q29kZQ==","owner":"band1hq8j5h0h64csk9tz95df783cxr0dt0dg3jw4p0"}}`
+	expected := `{"type":"zoracle/Store","value":{"code":"Q29kZQ==","name":"script name","owner":"band1hq8j5h0h64csk9tz95df783cxr0dt0dg3jw4p0"}}`
 
 	require.Equal(t, expected, string(res))
 }

--- a/chain/x/zoracle/internal/types/request.go
+++ b/chain/x/zoracle/internal/types/request.go
@@ -7,14 +7,16 @@ import (
 
 // Request is a type to store detail of request
 type Request struct {
+	Name        string `json:"name"`
 	CodeHash    []byte `json:"codeHash"`
 	Params      []byte `json:"params"`
 	ReportEndAt uint64 `json:"reportEnd"`
 }
 
 // NewRequest - contructor of Request struct
-func NewRequest(codeHash, params []byte, reportEndAt uint64) Request {
+func NewRequest(name string, codeHash, params []byte, reportEndAt uint64) Request {
 	return Request{
+		Name:        name,
 		CodeHash:    codeHash,
 		Params:      params,
 		ReportEndAt: reportEndAt,
@@ -22,9 +24,11 @@ func NewRequest(codeHash, params []byte, reportEndAt uint64) Request {
 }
 
 func (req Request) String() string {
-	return strings.TrimSpace(fmt.Sprintf(`CodeHash: %x
+	return strings.TrimSpace(fmt.Sprintf(`Name: %s
+CodeHash: %x
 Params: %x
 ReportEndAt: %d`,
+		req.Name,
 		req.CodeHash,
 		req.Params,
 		req.ReportEndAt,

--- a/chain/x/zoracle/internal/types/request.go
+++ b/chain/x/zoracle/internal/types/request.go
@@ -7,16 +7,14 @@ import (
 
 // Request is a type to store detail of request
 type Request struct {
-	Name        string `json:"name"`
 	CodeHash    []byte `json:"codeHash"`
 	Params      []byte `json:"params"`
 	ReportEndAt uint64 `json:"reportEnd"`
 }
 
 // NewRequest - contructor of Request struct
-func NewRequest(name string, codeHash, params []byte, reportEndAt uint64) Request {
+func NewRequest(codeHash, params []byte, reportEndAt uint64) Request {
 	return Request{
-		Name:        name,
 		CodeHash:    codeHash,
 		Params:      params,
 		ReportEndAt: reportEndAt,
@@ -24,11 +22,9 @@ func NewRequest(name string, codeHash, params []byte, reportEndAt uint64) Reques
 }
 
 func (req Request) String() string {
-	return strings.TrimSpace(fmt.Sprintf(`Name: %s
-CodeHash: %x
+	return strings.TrimSpace(fmt.Sprintf(`CodeHash: %x
 Params: %x
 ReportEndAt: %d`,
-		req.Name,
 		req.CodeHash,
 		req.Params,
 		req.ReportEndAt,

--- a/owasm/example/src/lib.rs
+++ b/owasm/example/src/lib.rs
@@ -52,11 +52,6 @@ pub fn __execute(params: u64, input: u64) -> u64 {
 }
 
 #[no_mangle]
-pub fn __name() -> u64 {
-    __return(&logic::name().into_bytes())
-}
-
-#[no_mangle]
 pub fn __params_info() -> u64 {
     __return(&serde_json::to_string(&logic::__Params::__fields()).ok().unwrap().into_bytes())
 }

--- a/owasm/example/src/logic.rs
+++ b/owasm/example/src/logic.rs
@@ -21,10 +21,6 @@ impl Data {
     }
 }
 
-pub fn name() -> String {
-    String::from("Crypto price")
-}
-
 pub fn execute(data: Vec<Data>) -> u64 {
     let mut total = 0.0;
     for each in &data {


### PR DESCRIPTION
fixed #166 

- Every msg will emit code name in event
- Code name must send to chain via MsgStoreCode
- Deprecate `Name()` in wasm part