### PR TITLE
docker reverse proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,7 +119,7 @@ services:
     depends_on:
       - rest-server
     ports:
-      - 1318:80
+      - 80:80
 
   web-server:
     image: band-validator:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
         ipv4_address: 172.18.0.11
     depends_on:
       - web-server
+      - proxy-server
     ports:
       - 26657:26657
     command: sh -c "chmod +x ./docker-config/single-validator/run.sh && ./docker-config/single-validator/run.sh"
@@ -40,6 +41,7 @@ services:
       - multi-validator3-node
       - multi-validator4-node
       - web-server
+      - proxy-server
 
   multi-validator1-node:
     build:
@@ -104,6 +106,18 @@ services:
     ports:
       - 1317:1317
     command: bandcli rest-server --laddr tcp://0.0.0.0:1317 --node tcp://172.18.0.11:26657 --chain-id bandchain
+
+  proxy-server:
+    build:
+      context: scan/proxy
+    image: proxy-server:latest
+    networks:
+      bandchain:
+        ipv4_address: 172.18.0.99
+    depends_on:
+      - rest-server
+    ports:
+      - 1318:80
 
   web-server:
     image: band-validator:latest

--- a/scan/README.md
+++ b/scan/README.md
@@ -12,7 +12,6 @@ yarn global add local-cors-proxy
 In 3 separate tabs:
 
 ```sh
-lcp --proxyUrl http://d3n.bandprotocol.com:1317/ --proxyPartial '' # Proxy server
 yarn bsb -make-world -w -ws _ # ReasonML compiler
 yarn parcel index.html # Serve to localhost:1234
 ```

--- a/scan/proxy/Dockerfile
+++ b/scan/proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM varnish:6.3
+
+COPY default.vcl /etc/varnish/

--- a/scan/proxy/default.vcl
+++ b/scan/proxy/default.vcl
@@ -1,0 +1,18 @@
+vcl 4.0;
+
+backend default {
+  .host = "172.18.0.15";
+  .port = "1317";
+}
+
+sub vcl_deliver {
+  if (req.url ~ "/") {
+    set resp.http.Access-Control-Allow-Origin = "*";
+    set resp.http.Access-Control-Allow-Methods = "GET, OPTIONS";
+    set resp.http.Access-Control-Allow-Headers = "Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token";
+  }
+}
+
+sub vcl_backend_response {
+    set beresp.ttl = 3s;
+}

--- a/scan/src/Index.re
+++ b/scan/src/Index.re
@@ -4,7 +4,8 @@ let style = document##createElement("style");
 document##head##appendChild(style);
 style##innerHTML #= AppStyle.style;
 
-Axios.setRpcUrl("http://localhost:8010/");
+Axios.setRpcUrl("http://d3n.bandprotocol.com:1318/");
+
 TimeAgos.setMomentRelativeTimeThreshold();
 
 ReactDOMRe.render(<GlobalContext> <App /> </GlobalContext>, document##getElementById("root"));

--- a/scan/src/Index.re
+++ b/scan/src/Index.re
@@ -4,7 +4,7 @@ let style = document##createElement("style");
 document##head##appendChild(style);
 style##innerHTML #= AppStyle.style;
 
-Axios.setRpcUrl("http://d3n.bandprotocol.com:1318/");
+Axios.setRpcUrl("https://d3n.bandprotocol.com/");
 
 TimeAgos.setMomentRelativeTimeThreshold();
 


### PR DESCRIPTION
Fixes #205, #279 
Right now, I prefer [Varnish](https://varnish-cache.org/docs/#) because it has a better cache configuration.

**Required Feature**
[x] Can it add CORS header? (Already added) [Source](https://gist.github.com/derekclee/a19ebfd7d22679c82fda)
[x] Can we set up different expiration time for different routes? [Source](https://www.linode.com/docs/websites/varnish/getting-started-with-varnish-cache/#advanced-varnish-configuration)
[x] Can we purge the cache with an external call?  [Source](https://www.wpoven.com/tutorial/how-to-purge-clear-varnish-cache-for-a-single-url/)
[x] How easy to inspect what's going on? Can we access the usage statistics? Error logs? [Source1](https://www.datadoghq.com/blog/how-to-collect-varnish-metrics/) or [Source2](https://pandorafms.com/blog/how-to-monitor-varnish-cache/)

[Template Example](https://github.com/mattiasgeniar/varnish-4.0-configuration-templates/blob/master/default.vcl)

More Interesting Source
https://book.varnish-software.com/4.0/chapters/VCL_Subroutines.html
https://gist.github.com/antonbabenko/8903578
https://www.varnish-software.com/wiki/content/tutorials/varnish/vcl.html#is-vcl-worth-the-learning-curve
https://varnish-cache.org/trac/wiki/VCLExamples
