### PR TITLE
add build-provider-image to depends_on

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       bandchain:
         ipv4_address: 172.18.0.11
     depends_on:
+      - build-provider-image
       - web-server
     ports:
       - 26657:26657
@@ -39,6 +40,7 @@ services:
       - multi-validator2-node
       - multi-validator3-node
       - multi-validator4-node
+      - build-provider-image
       - web-server
 
   multi-validator1-node:


### PR DESCRIPTION
add build-provider-image service to single and multi-validators' dependency in `docker-compose.yaml`