### PR TITLE
Use location.hostname to determine the config file for OWASM Studio

### DIFF
--- a/studio/ui/src/config.ts
+++ b/studio/ui/src/config.ts
@@ -33,7 +33,9 @@ export interface IConfig {
 }
 
 const configUrl =
-  process.env.ENV === "production" ? "./config.json" : "./config.dev.json";
+  window.location.hostname === "localhost"
+    ? "./config.dev.json"
+    : "./config.json";
 let config: IConfig;
 
 export default async function getConfig() {


### PR DESCRIPTION
fixed #351 