### PR TITLE
Allow getting proof with 3 precommits

### DIFF
--- a/chain/client/proof.go
+++ b/chain/client/proof.go
@@ -295,7 +295,7 @@ func GetBlockRelayProof(cliCtx context.CLIContext, blockId uint64) (BlockRelayPr
 		// 	lr1,
 		// })
 	}
-	if len(addrs) < 4 {
+	if len(addrs) < 3 {
 		return BlockRelayProof{}, fmt.Errorf("Too many invalid precommits")
 	}
 


### PR DESCRIPTION
In the case where 1 of the 4 validators on testnet stops helping produce blocks, the API should still return the proof.