### PR TITLE
owasm: Add CURL ext command

### DIFF
--- a/owasm/src/ext/utils/curl.rs
+++ b/owasm/src/ext/utils/curl.rs
@@ -1,0 +1,25 @@
+use crate::core::{Oracle, ShellCmd};
+
+pub struct Curl {
+    args: Vec<String>,
+}
+
+impl Curl {
+    pub fn new(args: &[impl AsRef<str>]) -> Curl {
+        Curl {
+            args: args.into_iter().map(|x| x.as_ref().into()).collect(),
+        }
+    }
+}
+
+impl Oracle for Curl {
+    type T = String;
+
+    fn as_cmd(&self) -> ShellCmd {
+        ShellCmd::new("curl", &self.args)
+    }
+
+    fn from_cmd_output(&self, output: String) -> Option<String> {
+        Some(output)
+    }
+}

--- a/owasm/src/ext/utils/mod.rs
+++ b/owasm/src/ext/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod curl;
 pub mod date;


### PR DESCRIPTION
A command to help everyone hacking up a new owasm script more easily.