### PR TITLE
Remove DataSourceCount in Request struct

### DIFF
--- a/chain/x/zoracle/internal/types/request.go
+++ b/chain/x/zoracle/internal/types/request.go
@@ -14,7 +14,6 @@ type Request struct {
 	RequestHeight            int64            `json:"requestHeight"`
 	RequestTime              int64            `json:"requestTime"`
 	ExpirationHeight         int64            `json:"expirationHeight"`
-	DataSourceCount          int64            `json:"dataSourceCount"`
 	IsResolved               bool             `json:"isResolved"`
 }
 


### PR DESCRIPTION
Remove don't use the field if you want to know data source count, you can call `GetRawDataRequestCount` at `keeper/raw_request.go`.