### PR TITLE
Rest-server for all oracle scripts route

### DIFF
--- a/chain/cmd/request/main.go
+++ b/chain/cmd/request/main.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/bandprotocol/d3n/chain/d3nlib"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -114,7 +116,7 @@ func main() {
 	// 	}
 	case "example":
 		{
-			file, err := os.Open("../../owasm/res/silly.wasm")
+			file, err := os.Open("../../owasm/res/silly/pkg/silly_bg.wasm")
 			if err != nil {
 				panic(err)
 			}
@@ -162,6 +164,43 @@ func main() {
 				0, 10000000, "", "", "",
 				flags.BroadcastBlock,
 			))
+		}
+	case "deploy_oracle_scripts":
+		{
+			file, err := os.Open("../../owasm/res/silly/pkg/silly_bg.wasm")
+			if err != nil {
+				panic(err)
+			}
+			defer file.Close()
+
+			stats, statsErr := file.Stat()
+			if statsErr != nil {
+				panic(statsErr)
+			}
+
+			size := stats.Size()
+			bytes := make([]byte, size)
+
+			bufr := bufio.NewReader(file)
+			_, err = bufr.Read(bytes)
+
+			if err != nil {
+				panic(err)
+			}
+
+			round, err := strconv.ParseUint(args[1], 10, 64)
+			if round <= 0 || err != nil {
+				panic("round should be more than 0")
+			}
+
+			for i := uint64(0); i < round; i++ {
+				fmt.Println(tx.SendTransaction(
+					[]sdk.Msg{zoracle.NewMsgCreateOracleScript(tx.Sender(), "Silly script", bytes, tx.Sender())},
+					0, 10000000, "", "", "",
+					flags.BroadcastBlock,
+				))
+				time.Sleep(100 * time.Millisecond)
+			}
 		}
 	}
 }

--- a/chain/cmd/request/main.go
+++ b/chain/cmd/request/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bufio"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -116,23 +116,7 @@ func main() {
 	// 	}
 	case "example":
 		{
-			file, err := os.Open("../../owasm/res/silly/pkg/silly_bg.wasm")
-			if err != nil {
-				panic(err)
-			}
-			defer file.Close()
-
-			stats, statsErr := file.Stat()
-			if statsErr != nil {
-				panic(statsErr)
-			}
-
-			size := stats.Size()
-			bytes := make([]byte, size)
-
-			bufr := bufio.NewReader(file)
-			_, err = bufr.Read(bytes)
-
+			bytes, err := ioutil.ReadFile("../../owasm/res/silly/pkg/silly_bg.wasm")
 			if err != nil {
 				panic(err)
 			}
@@ -167,23 +151,7 @@ func main() {
 		}
 	case "deploy_oracle_scripts":
 		{
-			file, err := os.Open("../../owasm/res/silly/pkg/silly_bg.wasm")
-			if err != nil {
-				panic(err)
-			}
-			defer file.Close()
-
-			stats, statsErr := file.Stat()
-			if statsErr != nil {
-				panic(statsErr)
-			}
-
-			size := stats.Size()
-			bytes := make([]byte, size)
-
-			bufr := bufio.NewReader(file)
-			_, err = bufr.Read(bytes)
-
+			bytes, err := ioutil.ReadFile("../../owasm/res/silly/pkg/silly_bg.wasm")
 			if err != nil {
 				panic(err)
 			}

--- a/chain/x/zoracle/client/rest/query.go
+++ b/chain/x/zoracle/client/rest/query.go
@@ -296,3 +296,27 @@ func getDataSourcesHandler(cliCtx context.CLIContext, storeName string) http.Han
 		rest.PostProcessResponse(w, cliCtx, queryDataSources)
 	}
 }
+
+func getOracleScriptsHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, page, limit, err := rest.ParseHTTPArgsWithLimit(r, 100)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		}
+
+		var queryOracleScripts []types.OracleScriptQuerierInfo
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/oracle_scripts/%d/%d", storeName, 1+(page-1)*limit, limit), nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		err = cliCtx.Codec.UnmarshalJSON(res, &queryOracleScripts)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, queryOracleScripts)
+	}
+}

--- a/chain/x/zoracle/client/rest/rest.go
+++ b/chain/x/zoracle/client/rest/rest.go
@@ -22,4 +22,5 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/request_number", storeName), getRequestNumberHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/data_source/{%s}", storeName, dataSourceIDTag), getDataSourceByIDHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/data_sources", storeName), getDataSourcesHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/oracle_scripts", storeName), getOracleScriptsHandler(cliCtx, storeName)).Methods("GET")
 }

--- a/chain/x/zoracle/internal/types/querier.go
+++ b/chain/x/zoracle/internal/types/querier.go
@@ -17,6 +17,7 @@ const (
 	QueryRequestNumber  = "request_number"
 	QueryDataSourceByID = "data_source"
 	QueryDataSources    = "data_sources"
+	QueryOracleScripts  = "oracle_scripts"
 )
 
 type U64Array []uint64
@@ -131,5 +132,26 @@ func NewDataSourceQuerierInfo(
 		Name:       name,
 		Fee:        fee,
 		Executable: executable,
+	}
+}
+
+type OracleScriptQuerierInfo struct {
+	ID    int64          `json:"id"`
+	Owner sdk.AccAddress `json:"owner`
+	Name  string         `json:"name"`
+	Code  []byte         `json:"code"`
+}
+
+func NewOracleScriptQuerierInfo(
+	id int64,
+	owner sdk.AccAddress,
+	name string,
+	code []byte,
+) OracleScriptQuerierInfo {
+	return OracleScriptQuerierInfo{
+		ID:    id,
+		Owner: owner,
+		Name:  name,
+		Code:  code,
 	}
 }


### PR DESCRIPTION
Fixes #558 
- `OracleScriptQuerierInfo` struct in `types/querier.go`
- `queryOracleScripts` function in `keeper/querier.go`
- New route `/zoracle/oracle_scripts?page=1&limit=10`
- add `deploy_oracle_scripts` case in order to test 