### PR TITLE
evm/bridges: Add price simple reference contracts

### DIFF
--- a/bridges/evm/contracts/reference/IPriceReference.sol
+++ b/bridges/evm/contracts/reference/IPriceReference.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.5.14;
+
+interface IPriceReference {
+    /// @dev Returns the number of times that the price has been updated.
+    function latestRound() external view returns (uint256);
+
+    /// @dev Returns the latest available price data point.
+    function latestAnswer() external view returns (uint256);
+
+    /// @dev Returns the timestamp associated with the latest available price.
+    function latestTimestamp() external view returns (uint256);
+
+    /// @dev Returns the price data point from the given round.
+    function getAnswer(uint256 _round) external view returns (uint256);
+
+    /// @dev Returns the timestamp associated with the price at the given round.
+    function getTimestamp(uint256 _round) external view returns (uint256);
+}

--- a/bridges/evm/contracts/reference/PriceReferenceProxy.sol
+++ b/bridges/evm/contracts/reference/PriceReferenceProxy.sol
@@ -1,0 +1,36 @@
+pragma solidity 0.5.14;
+
+import {Ownable} from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import {IPriceReference} from "./IPriceReference.sol";
+
+contract PriceReferenceProxy is IPriceReference, Ownable {
+    IPriceReference public impl;
+
+    constructor(IPriceReference _impl) public {
+        patchImpl(_impl);
+    }
+
+    function patchImpl(IPriceReference _impl) public onlyOwner {
+        impl = _impl;
+    }
+
+    function latestRound() public view returns (uint256) {
+        return impl.latestRound();
+    }
+
+    function latestAnswer() public view returns (uint256) {
+        return impl.latestAnswer();
+    }
+
+    function latestTimestamp() public view returns (uint256) {
+        return impl.latestTimestamp();
+    }
+
+    function getAnswer(uint256 _round) public view returns (uint256) {
+        return impl.getAnswer(_round);
+    }
+
+    function getTimestamp(uint256 _round) public view returns (uint256) {
+        return impl.getTimestamp(_round);
+    }
+}

--- a/bridges/evm/contracts/reference/SimplePriceReference.sol
+++ b/bridges/evm/contracts/reference/SimplePriceReference.sol
@@ -1,0 +1,38 @@
+pragma solidity 0.5.14;
+
+import {Ownable} from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import {IPriceReference} from "./IPriceReference.sol";
+
+contract SimplePriceReference is IPriceReference, Ownable {
+    uint256[] public prices;
+    uint256[] public timestamps;
+
+    constructor(uint256 _initialPrice) public {
+        pushPrice(_initialPrice);
+    }
+
+    function pushPrice(uint256 _price) public onlyOwner {
+        prices.push(_price);
+        timestamps.push(block.timestamp);
+    }
+
+    function latestRound() public view returns (uint256) {
+        return prices.length - 1;
+    }
+
+    function latestAnswer() public view returns (uint256) {
+        return getAnswer(latestRound());
+    }
+
+    function latestTimestamp() public view returns (uint256) {
+        return getTimestamp(latestRound());
+    }
+
+    function getAnswer(uint256 _round) public view returns (uint256) {
+        return prices[_round - 1];
+    }
+
+    function getTimestamp(uint256 _round) public view returns (uint256) {
+        return timestamps[_round - 1];
+    }
+}


### PR DESCRIPTION
A simple interface to consume price information. Implementation that relies on bridge will follow.