### PR TITLE
Fix rust dependency 

### DIFF
--- a/owasm/Cargo.toml
+++ b/owasm/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 json = "0.12.0"
 num = "*"
+quote = "=1.0.2"
 
 [workspace]
 members = [


### PR DESCRIPTION
Currently, our rust test will fail due to this [problem](https://users.rust-lang.org/t/failure-derive-compilation-error/39062)

Therefore we fix this package to solve the problem.