### PR TITLE
Make variables in bandoracled configurable via cobra

### DIFF
--- a/chain/cmd/bandoracled/main.go
+++ b/chain/cmd/bandoracled/main.go
@@ -77,7 +77,7 @@ $ bandoracled --node tcp://localhost:26657 --priv-key 06be35b56b048c5a6810a47e2e
 			if err != nil {
 				return err
 			}
-			fmt.Println(viper.GetString(flags.FlagNode), currentRequestID)
+
 			// Setup poll loop
 			for {
 				newRequestID, err := getLatestRequestID()

--- a/chain/cmd/bandoracled/main.go
+++ b/chain/cmd/bandoracled/main.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	flagQueryDuration = "query-duration"
-	flagPrivKey       = "priv-key"
+	flagMaxQueryDuration = "max-query-duration"
+	flagPrivKey          = "priv-key"
 )
 
 var (
@@ -47,6 +47,14 @@ func main() {
 	cmd := &cobra.Command{
 		Use:   "bandoracled",
 		Short: "Band oracle Daemon",
+		Long: strings.TrimSpace(
+			`Band oracle to listen new requests from chain and reports data for execution.
+Example:
+$ bandoracled --node tcp://localhost:26657 --priv-key 06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b -d 60
+`,
+		),
+		Args: cobra.NoArgs,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
@@ -87,8 +95,8 @@ func main() {
 
 	cmd.Flags().String(flags.FlagNode, "tcp://localhost:26657", "<host>:<port> to Tendermint RPC interface for this chain")
 	viper.BindPFlag(flags.FlagNode, cmd.Flags().Lookup(flags.FlagNode))
-	cmd.Flags().IntP(flagQueryDuration, "d", 60, "Max duration to query data")
-	viper.BindPFlag(flagQueryDuration, cmd.Flags().Lookup(flagQueryDuration))
+	cmd.Flags().IntP(flagMaxQueryDuration, "d", 60, "Max duration to query data")
+	viper.BindPFlag(flagMaxQueryDuration, cmd.Flags().Lookup(flagMaxQueryDuration))
 	cmd.Flags().String(
 		flagPrivKey,
 		"06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b",
@@ -146,7 +154,7 @@ func handleRequest(requestID int64) (sdk.TxResponse, error) {
 
 			result, err := byteexec.RunOnDocker(
 				dataSource.Executable,
-				time.Duration(viper.GetInt(flagQueryDuration))*time.Second,
+				time.Duration(viper.GetInt(flagMaxQueryDuration))*time.Second,
 				string(calldata),
 			)
 			if err != nil {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,15 +30,12 @@ services:
 
   single-oracle:
     image: band-validator:latest
-    environment:
-      - PRIVATE_KEY=06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b
-      - NODE_URI=tcp://172.18.0.15:26657
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       bandchain:
     restart: always
-    command: bandoracled
+    command: bandoracled --node tcp://172.18.0.15:26657 --priv-key 06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b
 
   multi-validator:
     image: tianon/true
@@ -71,15 +68,12 @@ services:
 
   oracle1:
     image: band-validator:latest
-    environment:
-      - PRIVATE_KEY=06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b
-      - NODE_URI=tcp://172.18.0.11:26657
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       bandchain:
     restart: always
-    command: bandoracled
+    command: bandoracled --node tcp://172.18.0.11:26657 --priv-key 06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b
 
   multi-validator2-node:
     image: band-validator:latest
@@ -90,15 +84,12 @@ services:
 
   oracle2:
     image: band-validator:latest
-    environment:
-      - PRIVATE_KEY=6abc8ab25298fb4af6adcb9d5831db0ad7c959388f0d947abd2b4c4457ef52ec
-      - NODE_URI=tcp://172.18.0.12:26657
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       bandchain:
     restart: always
-    command: bandoracled
+    command: bandoracled --node tcp://172.18.0.12:26657 --priv-key 6abc8ab25298fb4af6adcb9d5831db0ad7c959388f0d947abd2b4c4457ef52ec
 
   multi-validator3-node:
     image: band-validator:latest
@@ -109,15 +100,12 @@ services:
 
   oracle3:
     image: band-validator:latest
-    environment:
-      - PRIVATE_KEY=894fc1c7e7666c722ae5f30ba4cb18c546e08f0b2634718c27b80b9d39416dbe
-      - NODE_URI=tcp://172.18.0.13:26657
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       bandchain:
     restart: always
-    command: bandoracled
+    command: bandoracled --node tcp://172.18.0.13:26657 --priv-key 894fc1c7e7666c722ae5f30ba4cb18c546e08f0b2634718c27b80b9d39416dbe
 
   multi-validator4-node:
     image: band-validator:latest
@@ -128,15 +116,12 @@ services:
 
   oracle4:
     image: band-validator:latest
-    environment:
-      - PRIVATE_KEY=947f1715251d43de45232fc072e3ca4d823e876cf9f4ef74ad9a5f4ef440937e
-      - NODE_URI=tcp://172.18.0.14:26657
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       bandchain:
     restart: always
-    command: bandoracled
+    command: bandoracled --node tcp://172.18.0.14:26657 --priv-key 947f1715251d43de45232fc072e3ca4d823e876cf9f4ef74ad9a5f4ef440937e
 
   query-node:
     image: band-validator:latest


### PR DESCRIPTION
fixed #620 

After run `bandoracled --help`, this is a result.
```
Band oracle to listen new requests from chain and reports data for execution.
Example:
$ bandoracled --node tcp://localhost:26657 --priv-key 06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b -d 60

Usage:
  bandoracled [flags]

Flags:
  -h, --help                     help for bandoracled
  -d, --max-query-duration int   Max duration to query data (default 60)
      --node string              <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
      --priv-key string          Private key of validator to send report transaction (default "06be35b56b048c5a6810a47e2ef612eaed735ccb0d7ea4fc409f23f1d1a16e0b")
```