### PR TITLE
Revert "Fix dependency"

### DIFF
--- a/owasm/Cargo.toml
+++ b/owasm/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 json = "0.12.0"
 num = "*"
-quote = "=1.0.2"
 
 [workspace]
 members = [


### PR DESCRIPTION
This reverts commit 9dfd84e6fdad31a777539b38589a41c9038ae7f3.

It has already been solve at https://crates.io/crates/failure/0.1.7