### PR TITLE
chain: Add ExitCode to raw data report

### DIFF
--- a/chain/cmd/bandoracled/main.go
+++ b/chain/cmd/bandoracled/main.go
@@ -191,14 +191,14 @@ func handleRequest(requestID zoracle.RequestID) {
 		)
 	}
 
-	reports := make([]zoracle.RawDataReport, 0)
+	reports := make([]zoracle.RawDataReportWithID, 0)
 	for i := 0; i < len(request.RawDataRequests); i++ {
 		info := <-chanQueryParallelInfo
 		if info.err != nil {
 			logger.Error(fmt.Sprintf("Report fail on request #%d. Error: %v", requestID, info.err))
 			return
 		}
-		reports = append(reports, zoracle.NewRawDataReport(info.externalID, info.answer))
+		reports = append(reports, zoracle.NewRawDataReportWithID(info.externalID, 0, info.answer))
 	}
 
 	sort.Slice(reports, func(i, j int) bool {

--- a/chain/x/zoracle/alias.go
+++ b/chain/x/zoracle/alias.go
@@ -34,11 +34,12 @@ var (
 	DataSourceStoreKey   = types.DataSourceStoreKey
 	OracleScriptStoreKey = types.OracleScriptStoreKey
 
-	NewParams        = types.NewParams
-	NewDataSource    = types.NewDataSource
-	NewOracleScript  = types.NewOracleScript
-	DefaultParams    = types.DefaultParams
-	NewRawDataReport = types.NewRawDataReport
+	NewParams              = types.NewParams
+	NewDataSource          = types.NewDataSource
+	NewOracleScript        = types.NewOracleScript
+	DefaultParams          = types.DefaultParams
+	NewRawDataReport       = types.NewRawDataReport
+	NewRawDataReportWithID = types.NewRawDataReportWithID
 
 	KeyMaxDataSourceExecutableSize  = types.KeyMaxDataSourceExecutableSize
 	KeyMaxOracleScriptCodeSize      = types.KeyMaxOracleScriptCodeSize
@@ -68,6 +69,7 @@ type (
 	MsgEditOracleScript   = types.MsgEditOracleScript
 
 	RawDataReport         = types.RawDataReport
+	RawDataReportWithID   = types.RawDataReportWithID
 	RequestQuerierInfo    = types.RequestQuerierInfo
 	DataSourceQuerierInfo = types.DataSourceQuerierInfo
 

--- a/chain/x/zoracle/client/cli/tx.go
+++ b/chain/x/zoracle/client/cli/tx.go
@@ -174,7 +174,7 @@ $ %s tx zoracle report 1 5.0uband 1:172.5 2:HELLOWORLD --from mykey
 				return err
 			}
 
-			var dataset []types.RawDataReport
+			var dataset []types.RawDataReportWithID
 			for _, arg := range args[2:] {
 				reportRaw := strings.SplitN(arg, ":", 2)
 				if len(reportRaw) != 2 {
@@ -186,7 +186,8 @@ $ %s tx zoracle report 1 5.0uband 1:172.5 2:HELLOWORLD --from mykey
 				}
 				externalID := types.ExternalID(int64ExternalID)
 
-				dataset = append(dataset, types.NewRawDataReport(externalID, []byte(reportRaw[1])))
+				// TODO: Do not hardcode exit code
+				dataset = append(dataset, types.NewRawDataReportWithID(externalID, 0, []byte(reportRaw[1])))
 			}
 
 			// Sort data reports by external ID

--- a/chain/x/zoracle/client/rest/types.go
+++ b/chain/x/zoracle/client/rest/types.go
@@ -7,14 +7,14 @@ import (
 )
 
 type ReportDetail struct {
-	Reporter sdk.ValAddress        `json:"reporter"`
-	Value    []types.RawDataReport `json:"value"`
-	Tx       TxDetail              `json:"tx,omitempty"`
+	Reporter sdk.ValAddress              `json:"reporter"`
+	Value    []types.RawDataReportWithID `json:"value"`
+	Tx       TxDetail                    `json:"tx,omitempty"`
 }
 
 type RequestRESTInfo struct {
-	ID                       types.RequestID                                `json:"id"`
-	OracleScriptID           types.OracleScriptID                                `json:"oracleScriptID"`
+	ID                       types.RequestID                      `json:"id"`
+	OracleScriptID           types.OracleScriptID                 `json:"oracleScriptID"`
 	Calldata                 []byte                               `json:"calldata"`
 	RequestedValidators      []sdk.ValAddress                     `json:"requestedValidators"`
 	SufficientValidatorCount int64                                `json:"sufficientValidatorCount"`

--- a/chain/x/zoracle/exec_env.go
+++ b/chain/x/zoracle/exec_env.go
@@ -88,6 +88,14 @@ func (env *ExecutionEnvironment) GetExternalData(
 		return nil, errors.New("validator out of range")
 	}
 	validatorAddress := env.request.RequestedValidators[validatorIndex]
-
-	return env.keeper.GetRawDataReport(env.ctx, env.requestID, types.ExternalID(externalDataID), validatorAddress)
+	rawReport, err := env.keeper.GetRawDataReport(
+		env.ctx,
+		env.requestID,
+		types.ExternalID(externalDataID),
+		validatorAddress,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return rawReport.Data, nil
 }

--- a/chain/x/zoracle/exec_env_test.go
+++ b/chain/x/zoracle/exec_env_test.go
@@ -79,7 +79,7 @@ func TestGetReceivedValidatorCount(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, int64(0), env.GetReceivedValidatorCount())
 
-	keeper.AddReport(ctx, 1, []types.RawDataReport{}, sdk.ValAddress([]byte("val1")))
+	keeper.AddReport(ctx, 1, []types.RawDataReportWithID{}, sdk.ValAddress([]byte("val1")))
 
 	env, err = NewExecutionEnvironment(ctx, keeper, 1)
 	require.Nil(t, err)
@@ -112,7 +112,7 @@ func TestGetAggregateBlockTime(t *testing.T) {
 	require.Equal(t, int64(0), env.GetAggregateBlockTime())
 
 	// Add received validator
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{}, sdk.ValAddress([]byte("val1")))
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{}, sdk.ValAddress([]byte("val1")))
 	require.Nil(t, err)
 
 	// After report is greater or equal SufficientValidatorCount, it will resolve in current block time.
@@ -238,7 +238,13 @@ func TestGetExternalData(t *testing.T) {
 		1, 0, 0, 100, 10000,
 	))
 
-	keeper.SetRawDataReport(ctx, 1, 42, sdk.ValAddress([]byte("val1")), []byte("data42"))
+	keeper.SetRawDataReport(
+		ctx,
+		1,
+		42,
+		sdk.ValAddress([]byte("val1")),
+		types.NewRawDataReport(0, []byte("data42")),
+	)
 
 	env, err := NewExecutionEnvironment(ctx, keeper, 1)
 	require.Nil(t, err)

--- a/chain/x/zoracle/handler_test.go
+++ b/chain/x/zoracle/handler_test.go
@@ -287,8 +287,8 @@ func TestReportSuccess(t *testing.T) {
 	ctx = ctx.WithBlockHeight(5)
 	ctx = ctx.WithBlockTime(time.Unix(int64(1581589800), 0))
 
-	msg := types.NewMsgReportData(1, refundGasPrice, []types.RawDataReport{
-		types.NewRawDataReport(42, []byte("data1")),
+	msg := types.NewMsgReportData(1, refundGasPrice, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(42, 0, []byte("data1")),
 	}, validatorAddress1)
 
 	got := handleMsgReportData(ctx, keeper, msg)
@@ -296,8 +296,8 @@ func TestReportSuccess(t *testing.T) {
 	list := keeper.GetPendingResolveList(ctx)
 	require.Equal(t, []types.RequestID{}, list)
 
-	msg = types.NewMsgReportData(1, refundGasPrice, []types.RawDataReport{
-		types.NewRawDataReport(42, []byte("data2")),
+	msg = types.NewMsgReportData(1, refundGasPrice, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(42, 0, []byte("data2")),
 	}, validatorAddress2)
 
 	got = handleMsgReportData(ctx, keeper, msg)
@@ -346,8 +346,8 @@ func TestReportAndGetRefund(t *testing.T) {
 	ctx = ctx.WithBlockHeight(5)
 	ctx = ctx.WithBlockTime(time.Unix(int64(1581589800), 0))
 
-	msg := types.NewMsgReportData(1, sdk.NewDecCoins(sdk.NewCoins(sdk.NewCoin("uband", sdk.NewInt(10)))), []types.RawDataReport{
-		types.NewRawDataReport(42, []byte("data1")),
+	msg := types.NewMsgReportData(1, sdk.NewDecCoins(sdk.NewCoins(sdk.NewCoin("uband", sdk.NewInt(10)))), []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(42, 0, []byte("data1")),
 	}, validatorAddress1)
 
 	got := handleMsgReportData(ctx, keeper, msg)
@@ -355,7 +355,7 @@ func TestReportAndGetRefund(t *testing.T) {
 
 	// Should get refund back
 	balance = keeper.CoinKeeper.GetCoins(ctx, address1)
-	require.Equal(t, keep.NewUBandCoins(500000+128320), balance)
+	require.Equal(t, keep.NewUBandCoins(500000+128920), balance)
 }
 
 func TestReportFailed(t *testing.T) {
@@ -397,8 +397,8 @@ func TestReportFailed(t *testing.T) {
 
 	refundGasPrice, _ := sdk.ParseDecCoins("1.5uband")
 
-	msg := types.NewMsgReportData(1, refundGasPrice, []types.RawDataReport{
-		types.NewRawDataReport(41, []byte("data1")),
+	msg := types.NewMsgReportData(1, refundGasPrice, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(41, 0, []byte("data1")),
 	}, validatorAddress1)
 
 	// Test only 1 failed case, other case tested in keeper/report_test.go
@@ -432,8 +432,8 @@ func TestEndBlock(t *testing.T) {
 
 	handleMsgRequestData(ctx, keeper, msg)
 
-	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress1, []byte("answer1"))
-	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress2, []byte("answer2"))
+	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 
 	keeper.SetPendingResolveList(ctx, []types.RequestID{1})
 
@@ -489,8 +489,8 @@ func TestEndBlockExecuteFailedIfExecuteGasLessThanGasUsed(t *testing.T) {
 
 	handleMsgRequestData(ctx, keeper, msg)
 
-	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress1, []byte("answer1"))
-	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress2, []byte("answer2"))
+	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 
 	keeper.SetPendingResolveList(ctx, []types.RequestID{1})
 
@@ -534,11 +534,11 @@ func TestSkipInvalidExecuteGas(t *testing.T) {
 	msg = types.NewMsgRequestData(1, calldata, 2, 2, 100, 1000000, 50000, sender)
 	handleMsgRequestData(ctx, keeper, msg)
 
-	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress1, []byte("answer1"))
-	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress2, []byte("answer2"))
+	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+	keeper.SetRawDataReport(ctx, 1, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 
-	keeper.SetRawDataReport(ctx, 2, 1, validatorAddress1, []byte("answer1"))
-	keeper.SetRawDataReport(ctx, 2, 1, validatorAddress2, []byte("answer2"))
+	keeper.SetRawDataReport(ctx, 2, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+	keeper.SetRawDataReport(ctx, 2, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 
 	keeper.SetEndBlockExecuteGasLimit(ctx, 75000)
 
@@ -590,8 +590,8 @@ func TestStopResolveWhenOutOfGas(t *testing.T) {
 			types.NewMsgRequestData(scriptID, calldata, 2, 2, 100, 2000, 2500, sender),
 		)
 
-		keeper.SetRawDataReport(ctx, i, 1, validatorAddress1, []byte("answer1"))
-		keeper.SetRawDataReport(ctx, i, 1, validatorAddress2, []byte("answer2"))
+		keeper.SetRawDataReport(ctx, i, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+		keeper.SetRawDataReport(ctx, i, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 		pendingList = append(pendingList, i)
 	}
 
@@ -671,8 +671,8 @@ func TestStopResolveWhenOutOfGas(t *testing.T) {
 		require.Equal(t, types.Open, actualRequest.ResolveStatus)
 	}
 
-	keeper.SetRawDataReport(ctx, 11, 1, validatorAddress1, []byte("answer1"))
-	keeper.SetRawDataReport(ctx, 11, 1, validatorAddress2, []byte("answer2"))
+	keeper.SetRawDataReport(ctx, 11, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+	keeper.SetRawDataReport(ctx, 11, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 	keeper.SetPendingResolveList(ctx, []types.RequestID{10, 11})
 
 	got = handleEndBlock(ctx, keeper)
@@ -719,8 +719,8 @@ func TestEndBlockInsufficientExecutionConsumeEndBlockGas(t *testing.T) {
 			types.NewMsgRequestData(scriptID, calldata, 2, 2, 100, 2000, executeGasList[i-1], sender),
 		)
 
-		keeper.SetRawDataReport(ctx, i, 1, validatorAddress1, []byte("answer1"))
-		keeper.SetRawDataReport(ctx, i, 1, validatorAddress2, []byte("answer2"))
+		keeper.SetRawDataReport(ctx, i, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
+		keeper.SetRawDataReport(ctx, i, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 		pendingList = append(pendingList, i)
 	}
 

--- a/chain/x/zoracle/internal/keeper/querier.go
+++ b/chain/x/zoracle/internal/keeper/querier.go
@@ -48,16 +48,18 @@ func buildRequestQuerierInfo(
 	rawRequests := keeper.GetRawDataRequestWithExternalIDs(ctx, id)
 
 	iterator := keeper.GetRawDataReportsIterator(ctx, id)
-	reportMap := make(map[string]([]types.RawDataReport))
+	reportMap := make(map[string]([]types.RawDataReportWithID))
 	for ; iterator.Valid(); iterator.Next() {
 		validator, externalID := types.GetValidatorAddressAndExternalID(iterator.Key(), id)
 		if _, ok := reportMap[string(validator)]; !ok {
-			reportMap[string(validator)] = make([]types.RawDataReport, 0)
+			reportMap[string(validator)] = make([]types.RawDataReportWithID, 0)
 		}
 
+		var rawReport types.RawDataReport
+		keeper.cdc.MustUnmarshalBinaryBare(iterator.Value(), &rawReport)
 		reportMap[string(validator)] = append(
 			reportMap[string(validator)],
-			types.NewRawDataReport(externalID, iterator.Value()),
+			types.NewRawDataReportWithID(externalID, rawReport.ExitCode, rawReport.Data),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/querier_test.go
+++ b/chain/x/zoracle/internal/keeper/querier_test.go
@@ -184,11 +184,11 @@ func TestQueryRequestById(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 1, types.NewRawDataRequest(0, []byte("calldata1")))
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata2")))
 
-	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[0], []byte("report1"))
-	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[0], []byte("report2"))
+	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[0], types.NewRawDataReport(0, []byte("report1")))
+	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[0], types.NewRawDataReport(0, []byte("report2")))
 
-	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[1], []byte("report1-2"))
-	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[1], []byte("report2-2"))
+	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[1], types.NewRawDataReport(0, []byte("report1-2")))
+	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[1], types.NewRawDataReport(0, []byte("report2-2")))
 
 	data, _ := hex.DecodeString("0000000000002710")
 	keeper.SetResult(ctx, 1, request.OracleScriptID, request.Calldata, types.NewResult(1, 2, 3, 2, 2, data))
@@ -218,13 +218,13 @@ func TestQueryRequestById(t *testing.T) {
 				),
 			},
 			[]types.ReportWithValidator{
-				types.NewReportWithValidator([]types.RawDataReport{
-					types.NewRawDataReport(1, []byte("report1")),
-					types.NewRawDataReport(2, []byte("report2")),
+				types.NewReportWithValidator([]types.RawDataReportWithID{
+					types.NewRawDataReportWithID(1, 0, []byte("report1")),
+					types.NewRawDataReportWithID(2, 0, []byte("report2")),
 				}, request.RequestedValidators[0]),
-				types.NewReportWithValidator([]types.RawDataReport{
-					types.NewRawDataReport(1, []byte("report1-2")),
-					types.NewRawDataReport(2, []byte("report2-2")),
+				types.NewReportWithValidator([]types.RawDataReportWithID{
+					types.NewRawDataReportWithID(1, 0, []byte("report1-2")),
+					types.NewRawDataReportWithID(2, 0, []byte("report2-2")),
 				}, request.RequestedValidators[1]),
 			},
 			types.Result{
@@ -262,8 +262,8 @@ func TestQueryRequestIncompleteValidator(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 1, types.NewRawDataRequest(0, []byte("calldata1")))
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata2")))
 
-	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[1], []byte("report1-2"))
-	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[1], []byte("report2-2"))
+	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[1], types.NewRawDataReport(0, []byte("report1-2")))
+	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[1], types.NewRawDataReport(0, []byte("report2-2")))
 
 	// create query
 	acsBytes, err = querier(
@@ -290,9 +290,9 @@ func TestQueryRequestIncompleteValidator(t *testing.T) {
 				),
 			},
 			[]types.ReportWithValidator{
-				types.NewReportWithValidator([]types.RawDataReport{
-					types.NewRawDataReport(1, []byte("report1-2")),
-					types.NewRawDataReport(2, []byte("report2-2")),
+				types.NewReportWithValidator([]types.RawDataReportWithID{
+					types.NewRawDataReportWithID(1, 0, []byte("report1-2")),
+					types.NewRawDataReportWithID(2, 0, []byte("report2-2")),
 				}, request.RequestedValidators[1]),
 			},
 			types.Result{},
@@ -324,11 +324,11 @@ func TestQueryRequests(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 1, types.NewRawDataRequest(0, []byte("calldata1")))
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata2")))
 
-	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[0], []byte("report1"))
-	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[0], []byte("report2"))
+	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[0], types.NewRawDataReport(0, []byte("report1")))
+	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[0], types.NewRawDataReport(0, []byte("report2")))
 
-	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[1], []byte("report1-2"))
-	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[1], []byte("report2-2"))
+	keeper.SetRawDataReport(ctx, 1, 1, request.RequestedValidators[1], types.NewRawDataReport(0, []byte("report1-2")))
+	keeper.SetRawDataReport(ctx, 1, 2, request.RequestedValidators[1], types.NewRawDataReport(0, []byte("report2-2")))
 
 	data, _ := hex.DecodeString("0000000000002710")
 	result := types.Result{
@@ -374,13 +374,13 @@ func TestQueryRequests(t *testing.T) {
 					),
 				},
 				[]types.ReportWithValidator{
-					types.NewReportWithValidator([]types.RawDataReport{
-						types.NewRawDataReport(1, []byte("report1")),
-						types.NewRawDataReport(2, []byte("report2")),
+					types.NewReportWithValidator([]types.RawDataReportWithID{
+						types.NewRawDataReportWithID(1, 0, []byte("report1")),
+						types.NewRawDataReportWithID(2, 0, []byte("report2")),
 					}, request.RequestedValidators[0]),
-					types.NewReportWithValidator([]types.RawDataReport{
-						types.NewRawDataReport(1, []byte("report1-2")),
-						types.NewRawDataReport(2, []byte("report2-2")),
+					types.NewReportWithValidator([]types.RawDataReportWithID{
+						types.NewRawDataReportWithID(1, 0, []byte("report1-2")),
+						types.NewRawDataReportWithID(2, 0, []byte("report2-2")),
 					}, request.RequestedValidators[1]),
 				},
 				result,

--- a/chain/x/zoracle/internal/keeper/report.go
+++ b/chain/x/zoracle/internal/keeper/report.go
@@ -7,7 +7,10 @@ import (
 )
 
 func (k Keeper) AddReport(
-	ctx sdk.Context, requestID types.RequestID, dataSet []types.RawDataReport, validator sdk.ValAddress,
+	ctx sdk.Context,
+	requestID types.RequestID,
+	dataSet []types.RawDataReportWithID,
+	validator sdk.ValAddress,
 ) sdk.Error {
 	request, err := k.GetRequest(ctx, requestID)
 	if err != nil {
@@ -85,7 +88,16 @@ func (k Keeper) AddReport(
 				k.MaxRawDataReportSize(ctx),
 			)
 		}
-		k.SetRawDataReport(ctx, requestID, rawReport.ExternalDataID, validator, rawReport.Data)
+		k.SetRawDataReport(
+			ctx,
+			requestID,
+			rawReport.ExternalDataID,
+			validator,
+			types.RawDataReport{
+				ExitCode: rawReport.ExitCode,
+				Data:     rawReport.Data,
+			},
+		)
 		lastExternalID = rawReport.ExternalDataID
 	}
 
@@ -107,11 +119,11 @@ func (k Keeper) SetRawDataReport(
 	ctx sdk.Context,
 	requestID types.RequestID, externalID types.ExternalID,
 	validatorAddress sdk.ValAddress,
-	data []byte,
+	rawDataReport types.RawDataReport,
 ) {
 	key := types.RawDataReportStoreKey(requestID, externalID, validatorAddress)
 	store := ctx.KVStore(k.storeKey)
-	store.Set(key, data)
+	store.Set(key, k.cdc.MustMarshalBinaryBare(rawDataReport))
 }
 
 // GetRawDataReport is a function that gets a raw data report from store.
@@ -119,18 +131,21 @@ func (k Keeper) GetRawDataReport(
 	ctx sdk.Context,
 	requestID types.RequestID, externalID types.ExternalID,
 	validatorAddress sdk.ValAddress,
-) ([]byte, sdk.Error) {
+) (types.RawDataReport, sdk.Error) {
 	key := types.RawDataReportStoreKey(requestID, externalID, validatorAddress)
 	store := ctx.KVStore(k.storeKey)
 	if !store.Has(key) {
-		return nil, types.ErrItemNotFound(
+		return types.RawDataReport{}, types.ErrItemNotFound(
 			"GetRawDataReport: Unable to find raw data report with request ID %d external ID %d from %s",
 			requestID,
 			externalID,
 			validatorAddress.String(),
 		)
 	}
-	return store.Get(key), nil
+	bz := store.Get(key)
+	var rawDataReport types.RawDataReport
+	k.cdc.MustUnmarshalBinaryBare(bz, &rawDataReport)
+	return rawDataReport, nil
 }
 
 // GetRawDataReportsIterator returns an iterator for all reports for a specific request ID.

--- a/chain/x/zoracle/internal/keeper/report_test.go
+++ b/chain/x/zoracle/internal/keeper/report_test.go
@@ -13,11 +13,11 @@ func TestGetterSetterRawDataReport(t *testing.T) {
 
 	validatorAddress1, _ := sdk.ValAddressFromHex("4aea6cfc5bd14f2308954d544e1dc905268357db")
 
-	keeper.SetRawDataReport(ctx, 1, 3, validatorAddress1, []byte("Data1/3"))
+	keeper.SetRawDataReport(ctx, 1, 3, validatorAddress1, types.NewRawDataReport(0, []byte("Data1/3")))
 
 	report, err := keeper.GetRawDataReport(ctx, 1, 3, validatorAddress1)
 	require.Nil(t, err)
-	require.Equal(t, []byte("Data1/3"), report)
+	require.Equal(t, types.NewRawDataReport(0, []byte("Data1/3")), report)
 
 	_, err = keeper.GetRawDataReport(ctx, 2, 3, validatorAddress1)
 	require.Equal(t, types.CodeItemNotFound, err.Code())
@@ -38,9 +38,9 @@ func TestAddReportSuccess(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata1")))
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
-	err := keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/1")),
-		types.NewRawDataReport(10, []byte("data2/1")),
+	err := keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 1, []byte("data1/1")),
+		types.NewRawDataReportWithID(10, 0, []byte("data2/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 
 	require.Nil(t, err)
@@ -50,28 +50,28 @@ func TestAddReportSuccess(t *testing.T) {
 
 	report, err := keeper.GetRawDataReport(ctx, 1, 2, sdk.ValAddress([]byte("validator1")))
 	require.Nil(t, err)
-	require.Equal(t, []byte("data1/1"), report)
+	require.Equal(t, types.NewRawDataReport(1, []byte("data1/1")), report)
 
 	report, err = keeper.GetRawDataReport(ctx, 1, 10, sdk.ValAddress([]byte("validator1")))
 	require.Nil(t, err)
-	require.Equal(t, []byte("data2/1"), report)
+	require.Equal(t, types.NewRawDataReport(0, []byte("data2/1")), report)
 
 	list := keeper.GetPendingResolveList(ctx)
 	require.Equal(t, []types.RequestID{}, list)
 
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/2")),
-		types.NewRawDataReport(10, []byte("data2/2")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("data1/2")),
+		types.NewRawDataReportWithID(10, 2, []byte("data2/2")),
 	}, sdk.ValAddress([]byte("validator2")))
 	require.Nil(t, err)
 
 	report, err = keeper.GetRawDataReport(ctx, 1, 2, sdk.ValAddress([]byte("validator2")))
 	require.Nil(t, err)
-	require.Equal(t, []byte("data1/2"), report)
+	require.Equal(t, types.NewRawDataReport(0, []byte("data1/2")), report)
 
 	report, err = keeper.GetRawDataReport(ctx, 1, 10, sdk.ValAddress([]byte("validator2")))
 	require.Nil(t, err)
-	require.Equal(t, []byte("data2/2"), report)
+	require.Equal(t, types.NewRawDataReport(2, []byte("data2/2")), report)
 
 	list = keeper.GetPendingResolveList(ctx)
 	require.Equal(t, []types.RequestID{1}, list)
@@ -81,9 +81,9 @@ func TestAddReportFailed(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	// Send report on invalid request.
-	err := keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/1")),
-		types.NewRawDataReport(10, []byte("data2/1")),
+	err := keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("data1/1")),
+		types.NewRawDataReportWithID(10, 0, []byte("data2/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.NotNil(t, err)
 
@@ -95,9 +95,9 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata1")))
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/1")),
-		types.NewRawDataReport(10, []byte("data2/1")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("data1/1")),
+		types.NewRawDataReportWithID(10, 0, []byte("data2/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.NotNil(t, err)
 
@@ -108,9 +108,9 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata1")))
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/1")),
-		types.NewRawDataReport(10, []byte("data2/1")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("data1/1")),
+		types.NewRawDataReportWithID(10, 0, []byte("data2/1")),
 	}, sdk.ValAddress([]byte("nonvalidator")))
 	require.NotNil(t, err)
 
@@ -123,9 +123,9 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
 	ctx = ctx.WithBlockHeight(6)
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/1")),
-		types.NewRawDataReport(10, []byte("data2/1")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("data1/1")),
+		types.NewRawDataReportWithID(10, 0, []byte("data2/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.NotNil(t, err)
 
@@ -137,8 +137,8 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
 	ctx = ctx.WithBlockHeight(2)
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("data1/1")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("data1/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.NotNil(t, err)
 
@@ -150,9 +150,9 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
 	ctx = ctx.WithBlockHeight(2)
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(10, []byte("data2/1")),
-		types.NewRawDataReport(2, []byte("data1/1")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(10, 0, []byte("data2/1")),
+		types.NewRawDataReportWithID(2, 0, []byte("data1/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.NotNil(t, err)
 
@@ -164,9 +164,9 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
 	ctx = ctx.WithBlockHeight(2)
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(3, []byte("data2/1")),
-		types.NewRawDataReport(10, []byte("data1/1")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(3, 0, []byte("data2/1")),
+		types.NewRawDataReportWithID(10, 0, []byte("data1/1")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.NotNil(t, err)
 
@@ -178,15 +178,15 @@ func TestAddReportFailed(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 10, types.NewRawDataRequest(2, []byte("calldata2")))
 
 	ctx = ctx.WithBlockHeight(2)
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("OldValue1")),
-		types.NewRawDataReport(10, []byte("OldValue2")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("OldValue1")),
+		types.NewRawDataReportWithID(10, 0, []byte("OldValue2")),
 	}, sdk.ValAddress([]byte("validator2")))
 	require.Nil(t, err)
 
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("NewValue1")),
-		types.NewRawDataReport(10, []byte("NewValue2")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("NewValue1")),
+		types.NewRawDataReportWithID(10, 0, []byte("NewValue2")),
 	}, sdk.ValAddress([]byte("validator2")))
 	require.NotNil(t, err)
 
@@ -228,14 +228,14 @@ func TestAddReportReportSizeExceedMaxRawDataReportSize(t *testing.T) {
 	keeper.SetRawDataRequest(ctx, 1, 2, types.NewRawDataRequest(1, []byte("calldata")))
 
 	// Size of "short report" is 12 bytes which is shorter than 20 bytes.
-	err := keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("short report")),
+	err := keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("short report")),
 	}, sdk.ValAddress([]byte("validator1")))
 	require.Nil(t, err)
 
 	// Size of "a report that obviously longer than 20 bytes" is 44 bytes.
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{
-		types.NewRawDataReport(2, []byte("a report that obviously longer than 20 bytes")),
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{
+		types.NewRawDataReportWithID(2, 0, []byte("a report that obviously longer than 20 bytes")),
 	}, sdk.ValAddress([]byte("validator2")))
 	require.NotNil(t, err)
 

--- a/chain/x/zoracle/internal/keeper/request_test.go
+++ b/chain/x/zoracle/internal/keeper/request_test.go
@@ -254,11 +254,11 @@ func TestHasToPutInPendingList(t *testing.T) {
 	keeper.SetRequest(ctx, 1, request)
 	require.False(t, keeper.ShouldBecomePendingResolve(ctx, 1))
 
-	err := keeper.AddReport(ctx, 1, []types.RawDataReport{}, sdk.ValAddress([]byte("validator1")))
+	err := keeper.AddReport(ctx, 1, []types.RawDataReportWithID{}, sdk.ValAddress([]byte("validator1")))
 	require.Nil(t, err)
 	require.True(t, keeper.ShouldBecomePendingResolve(ctx, 1))
 
-	err = keeper.AddReport(ctx, 1, []types.RawDataReport{}, sdk.ValAddress([]byte("validator2")))
+	err = keeper.AddReport(ctx, 1, []types.RawDataReportWithID{}, sdk.ValAddress([]byte("validator2")))
 	require.Nil(t, err)
 	require.False(t, keeper.ShouldBecomePendingResolve(ctx, 1))
 }

--- a/chain/x/zoracle/internal/types/msgs.go
+++ b/chain/x/zoracle/internal/types/msgs.go
@@ -100,17 +100,17 @@ func (msg MsgRequestData) GetSignBytes() []byte {
 
 // MsgReportData is a message sent by each of the block validators to respond to a data request.
 type MsgReportData struct {
-	RequestID      RequestID       `json:"requestID"`
-	RefundGasPrice sdk.DecCoins    `json:"refundGasPrice"`
-	DataSet        []RawDataReport `json:"dataSet"`
-	Sender         sdk.ValAddress  `json:"sender"`
+	RequestID      RequestID             `json:"requestID"`
+	RefundGasPrice sdk.DecCoins          `json:"refundGasPrice"`
+	DataSet        []RawDataReportWithID `json:"dataSet"`
+	Sender         sdk.ValAddress        `json:"sender"`
 }
 
 // NewMsgReportData creates a new MsgReportData instance.
 func NewMsgReportData(
 	requestID RequestID,
 	refundGasPrice sdk.DecCoins,
-	dataSet []RawDataReport,
+	dataSet []RawDataReportWithID,
 	sender sdk.ValAddress,
 ) MsgReportData {
 	return MsgReportData{

--- a/chain/x/zoracle/internal/types/msgs_test.go
+++ b/chain/x/zoracle/internal/types/msgs_test.go
@@ -120,7 +120,7 @@ func TestMsgRequestDataGetSignBytes(t *testing.T) {
 
 func TestMsgReportData(t *testing.T) {
 	requestID := RequestID(3)
-	data := []RawDataReport{NewRawDataReport(1, []byte("data1")), NewRawDataReport(2, []byte("data2"))}
+	data := []RawDataReportWithID{NewRawDataReportWithID(1, 1, []byte("data1")), NewRawDataReportWithID(2, 2, []byte("data2"))}
 	provider, _ := sdk.ValAddressFromHex("b80f2a5df7d5710b15622d1a9f1e3830ded5bda8")
 
 	msg := NewMsgReportData(requestID, sdk.NewDecCoins(sdk.NewCoins(sdk.NewCoin("uband", sdk.NewInt(1000)))), data, provider)
@@ -131,7 +131,7 @@ func TestMsgReportData(t *testing.T) {
 
 func TestMsgReportDataValidation(t *testing.T) {
 	requestID := RequestID(3)
-	data := []RawDataReport{NewRawDataReport(1, []byte("data1")), NewRawDataReport(2, []byte("data2"))}
+	data := []RawDataReportWithID{NewRawDataReportWithID(1, 1, []byte("data1")), NewRawDataReportWithID(2, 2, []byte("data2"))}
 	validator, _ := sdk.ValAddressFromHex("b80f2a5df7d5710b15622d1a9f1e3830ded5bda8")
 	failValidator, _ := sdk.ValAddressFromHex("")
 	refundGasFeePos, _ := sdk.ParseDecCoins("0.1uband")
@@ -146,7 +146,7 @@ func TestMsgReportDataValidation(t *testing.T) {
 		{true, NewMsgReportData(requestID, refundGasFeeZero, data, validator)},
 		{false, NewMsgReportData(requestID, refundGasFeeNeg, data, validator)},
 		{false, NewMsgReportData(-1, refundGasFeeZero, data, validator)},
-		{false, NewMsgReportData(requestID, refundGasFeeZero, []RawDataReport{}, validator)},
+		{false, NewMsgReportData(requestID, refundGasFeeZero, []RawDataReportWithID{}, validator)},
 		{false, NewMsgReportData(requestID, refundGasFeeZero, nil, validator)},
 		{false, NewMsgReportData(requestID, refundGasFeeZero, data, failValidator)},
 	}
@@ -166,12 +166,12 @@ func TestMsgReportDataGetSignBytes(t *testing.T) {
 	config.SetBech32PrefixForValidator("band"+sdk.PrefixValidator+sdk.PrefixOperator, "band"+sdk.PrefixValidator+sdk.PrefixOperator+sdk.PrefixPublic)
 
 	requestID := RequestID(3)
-	data := []RawDataReport{NewRawDataReport(1, []byte("data1")), NewRawDataReport(2, []byte("data2"))}
+	data := []RawDataReportWithID{NewRawDataReportWithID(1, 1, []byte("data1")), NewRawDataReportWithID(2, 2, []byte("data2"))}
 	validator, _ := sdk.ValAddressFromHex("b80f2a5df7d5710b15622d1a9f1e3830ded5bda8")
 	msg := NewMsgReportData(requestID, sdk.NewDecCoins(sdk.NewCoins(sdk.NewCoin("uband", sdk.NewInt(1000)))), data, validator)
 	res := msg.GetSignBytes()
 
-	expected := `{"type":"zoracle/Report","value":{"dataSet":[{"data":"ZGF0YTE=","externalDataID":"1"},{"data":"ZGF0YTI=","externalDataID":"2"}],"refundGasPrice":[{"amount":"1000.000000000000000000","denom":"uband"}],"requestID":"3","sender":"bandvaloper1hq8j5h0h64csk9tz95df783cxr0dt0dgay2kyy"}}`
+	expected := `{"type":"zoracle/Report","value":{"dataSet":[{"data":"ZGF0YTE=","exitCode":1,"externalDataID":"1"},{"data":"ZGF0YTI=","exitCode":2,"externalDataID":"2"}],"refundGasPrice":[{"amount":"1000.000000000000000000","denom":"uband"}],"requestID":"3","sender":"bandvaloper1hq8j5h0h64csk9tz95df783cxr0dt0dgay2kyy"}}`
 
 	require.Equal(t, expected, string(res))
 }

--- a/chain/x/zoracle/internal/types/report.go
+++ b/chain/x/zoracle/internal/types/report.go
@@ -4,29 +4,43 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// RawDataReport encapsulates a raw data report for an external data source from a block validator.
 type RawDataReport struct {
+	ExitCode uint8  `json:"exitCode"`
+	Data     []byte `json:"data"`
+}
+
+func NewRawDataReport(exitCode uint8, data []byte) RawDataReport {
+	return RawDataReport{
+		ExitCode: exitCode,
+		Data:     data,
+	}
+}
+
+// RawDataReport encapsulates a raw data report for an external data source from a block validator.
+type RawDataReportWithID struct {
 	ExternalDataID ExternalID `json:"externalDataID"`
+	ExitCode       uint8      `json:"exitCode"`
 	Data           []byte     `json:"data"`
 }
 
 // NewRawDataReport creates a new RawDataReport instance.
-func NewRawDataReport(externalDataID ExternalID, data []byte) RawDataReport {
-	return RawDataReport{
+func NewRawDataReportWithID(externalDataID ExternalID, exitCode uint8, data []byte) RawDataReportWithID {
+	return RawDataReportWithID{
 		ExternalDataID: externalDataID,
+		ExitCode:       exitCode,
 		Data:           data,
 	}
 }
 
-// ReportWithValidator is a report that contain operator address in struct
+// ReportWithValidator is a report that contains operator address in struct
 type ReportWithValidator struct {
-	RawDataReports []RawDataReport `json:"detail"`
-	Validator      sdk.ValAddress  `json:"validator"`
+	RawDataReports []RawDataReportWithID `json:"detail"`
+	Validator      sdk.ValAddress        `json:"validator"`
 }
 
 // NewReportWithValidator is a contructor of ReportWithValidator
 func NewReportWithValidator(
-	reports []RawDataReport,
+	reports []RawDataReportWithID,
 	valAddress sdk.ValAddress,
 
 ) ReportWithValidator {


### PR DESCRIPTION
This allows data reporters to additionally specify result for data source script runs in more details.