### PR TITLE
chain: set ResolveStatus type to int8

### DIFF
--- a/chain/x/zoracle/internal/types/request.go
+++ b/chain/x/zoracle/internal/types/request.go
@@ -4,7 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-type ResolveStatus int
+type ResolveStatus int8
 
 const (
 	Open ResolveStatus = iota


### PR DESCRIPTION
You would think using a type with a fixed size is better, right?