### PR TITLE
chain: Convert params to uint64 and introduce one function to read them

### DIFF
--- a/chain/x/zoracle/alias.go
+++ b/chain/x/zoracle/alias.go
@@ -49,12 +49,16 @@ var (
 	NewRawDataReport       = types.NewRawDataReport
 	NewRawDataReportWithID = types.NewRawDataReportWithID
 
-	KeyMaxDataSourceExecutableSize  = types.KeyMaxDataSourceExecutableSize
-	KeyMaxOracleScriptCodeSize      = types.KeyMaxOracleScriptCodeSize
-	KeyMaxCalldataSize              = types.KeyMaxCalldataSize
-	KeyMaxDataSourceCountPerRequest = types.KeyMaxDataSourceCountPerRequest
-	KeyMaxRawDataReportSize         = types.KeyMaxRawDataReportSize
-	KeyMaxResultSize                = types.KeyMaxResultSize
+	KeyMaxDataSourceExecutableSize      = types.KeyMaxDataSourceExecutableSize
+	KeyMaxOracleScriptCodeSize          = types.KeyMaxOracleScriptCodeSize
+	KeyMaxCalldataSize                  = types.KeyMaxCalldataSize
+	KeyMaxDataSourceCountPerRequest     = types.KeyMaxDataSourceCountPerRequest
+	KeyMaxRawDataReportSize             = types.KeyMaxRawDataReportSize
+	KeyMaxResultSize                    = types.KeyMaxResultSize
+	KeyMaxNameLength                    = types.KeyMaxNameLength
+	KeyMaxDescriptionLength             = types.KeyMaxDescriptionLength
+	KeyEndBlockExecuteGasLimit          = types.KeyEndBlockExecuteGasLimit
+	KeyGasPerRawDataRequestPerValidator = types.KeyGasPerRawDataRequestPerValidator
 
 	QueryRequestByID    = types.QueryRequestByID
 	QueryRequests       = types.QueryRequests

--- a/chain/x/zoracle/endblock.go
+++ b/chain/x/zoracle/endblock.go
@@ -18,7 +18,7 @@ func addUint64Overflow(a, b uint64) (uint64, bool) {
 
 func handleEndBlock(ctx sdk.Context, keeper Keeper) sdk.Result {
 	pendingList := keeper.GetPendingResolveList(ctx)
-	endBlockExecuteGasLimit := keeper.EndBlockExecuteGasLimit(ctx)
+	endBlockExecuteGasLimit := keeper.GetParam(ctx, types.KeyEndBlockExecuteGasLimit)
 	gasConsumed := uint64(0)
 	firstUnresolvedRequestIndex := len(pendingList)
 

--- a/chain/x/zoracle/exec_env.go
+++ b/chain/x/zoracle/exec_env.go
@@ -3,9 +3,8 @@ package zoracle
 import (
 	"errors"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/bandprotocol/bandchain/chain/x/zoracle/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type ExecutionEnvironment struct {
@@ -65,11 +64,11 @@ func (env *ExecutionEnvironment) GetValidatorAddress(validatorIndex int64) ([]by
 }
 
 func (env *ExecutionEnvironment) GetMaximumResultSize() int64 {
-	return env.keeper.MaxResultSize(env.ctx)
+	return int64(env.keeper.GetParam(env.ctx, KeyMaxResultSize))
 }
 
 func (env *ExecutionEnvironment) GetMaximumCalldataOfDataSourceSize() int64 {
-	return env.keeper.MaxCalldataSize(env.ctx)
+	return int64(env.keeper.GetParam(env.ctx, KeyMaxCalldataSize))
 }
 
 func (env *ExecutionEnvironment) RequestExternalData(

--- a/chain/x/zoracle/exec_env_test.go
+++ b/chain/x/zoracle/exec_env_test.go
@@ -213,7 +213,7 @@ func TestRequestExternalDataExceedMaxDataSourceCountPerRequest(t *testing.T) {
 	require.Nil(t, err)
 
 	// Set MaxDataSourceCountPerRequest to 5
-	keeper.SetMaxDataSourceCountPerRequest(ctx, 5)
+	keeper.SetParam(ctx, KeyMaxDataSourceCountPerRequest, 5)
 	envErr := env.RequestExternalData(1, 41, []byte("prepare32"))
 	require.Nil(t, envErr)
 	envErr = env.RequestExternalData(1, 42, []byte("prepare32"))

--- a/chain/x/zoracle/genesis.go
+++ b/chain/x/zoracle/genesis.go
@@ -38,16 +38,16 @@ func DefaultGenesisState() GenesisState {
 }
 
 func InitGenesis(ctx sdk.Context, k Keeper, data GenesisState) []abci.ValidatorUpdate {
-	k.SetMaxDataSourceExecutableSize(ctx, data.Params.MaxDataSourceExecutableSize)
-	k.SetMaxOracleScriptCodeSize(ctx, data.Params.MaxOracleScriptCodeSize)
-	k.SetMaxCalldataSize(ctx, data.Params.MaxCalldataSize)
-	k.SetMaxDataSourceCountPerRequest(ctx, data.Params.MaxDataSourceCountPerRequest)
-	k.SetMaxRawDataReportSize(ctx, data.Params.MaxRawDataReportSize)
-	k.SetMaxResultSize(ctx, data.Params.MaxResultSize)
-	k.SetEndBlockExecuteGasLimit(ctx, data.Params.EndBlockExecuteGasLimit)
-	k.SetMaxNameLength(ctx, data.Params.MaxNameLength)
-	k.SetMaxDescriptionLength(ctx, data.Params.MaxDescriptionLength)
-	k.SetGasPerRawDataRequestPerValidator(ctx, data.Params.GasPerRawDataRequestPerValidator)
+	k.SetParam(ctx, KeyMaxDataSourceExecutableSize, data.Params.MaxDataSourceExecutableSize)
+	k.SetParam(ctx, KeyMaxOracleScriptCodeSize, data.Params.MaxOracleScriptCodeSize)
+	k.SetParam(ctx, KeyMaxCalldataSize, data.Params.MaxCalldataSize)
+	k.SetParam(ctx, KeyMaxDataSourceCountPerRequest, data.Params.MaxDataSourceCountPerRequest)
+	k.SetParam(ctx, KeyMaxRawDataReportSize, data.Params.MaxRawDataReportSize)
+	k.SetParam(ctx, KeyMaxResultSize, data.Params.MaxResultSize)
+	k.SetParam(ctx, KeyEndBlockExecuteGasLimit, data.Params.EndBlockExecuteGasLimit)
+	k.SetParam(ctx, KeyMaxNameLength, data.Params.MaxNameLength)
+	k.SetParam(ctx, KeyMaxDescriptionLength, data.Params.MaxDescriptionLength)
+	k.SetParam(ctx, KeyGasPerRawDataRequestPerValidator, data.Params.GasPerRawDataRequestPerValidator)
 
 	for _, dataSource := range data.DataSources {
 		_, err := k.AddDataSource(

--- a/chain/x/zoracle/handler_test.go
+++ b/chain/x/zoracle/handler_test.go
@@ -585,7 +585,7 @@ func TestSkipInvalidExecuteGas(t *testing.T) {
 	keeper.SetRawDataReport(ctx, 2, 1, validatorAddress1, types.NewRawDataReport(0, []byte("answer1")))
 	keeper.SetRawDataReport(ctx, 2, 1, validatorAddress2, types.NewRawDataReport(0, []byte("answer2")))
 
-	keeper.SetEndBlockExecuteGasLimit(ctx, 75000)
+	keeper.SetParam(ctx, KeyEndBlockExecuteGasLimit, 75000)
 
 	keeper.SetPendingResolveList(ctx, []types.RequestID{1, 2})
 	got := handleEndBlock(ctx, keeper)
@@ -641,7 +641,7 @@ func TestStopResolveWhenOutOfGas(t *testing.T) {
 	}
 
 	// Each execute use 2270 gas, so it can resolve 3 requests per block
-	keeper.SetEndBlockExecuteGasLimit(ctx, 7500)
+	keeper.SetParam(ctx, KeyEndBlockExecuteGasLimit, 7500)
 	keeper.SetPendingResolveList(ctx, pendingList)
 
 	got := handleEndBlock(ctx, keeper)
@@ -769,7 +769,7 @@ func TestEndBlockInsufficientExecutionConsumeEndBlockGas(t *testing.T) {
 		pendingList = append(pendingList, i)
 	}
 
-	keeper.SetEndBlockExecuteGasLimit(ctx, 2600)
+	keeper.SetParam(ctx, KeyEndBlockExecuteGasLimit, 2600)
 	keeper.SetPendingResolveList(ctx, pendingList)
 
 	got := handleEndBlock(ctx, keeper)

--- a/chain/x/zoracle/internal/keeper/data_source.go
+++ b/chain/x/zoracle/internal/keeper/data_source.go
@@ -18,22 +18,22 @@ func (k Keeper) AddDataSource(
 	ctx sdk.Context, owner sdk.AccAddress, name string, description string,
 	fee sdk.Coins, executable []byte,
 ) (types.DataSourceID, sdk.Error) {
-	if int64(len(executable)) > k.MaxDataSourceExecutableSize(ctx) {
+	if uint64(len(executable)) > k.GetParam(ctx, types.KeyMaxDataSourceExecutableSize) {
 		return 0, types.ErrBadDataValue(
 			"AddDataSource: Executable size (%d) exceeds the maximum size (%d).",
-			len(executable), int(k.MaxDataSourceExecutableSize(ctx)),
+			len(executable), k.GetParam(ctx, types.KeyMaxDataSourceExecutableSize),
 		)
 	}
-	if int64(len(name)) > k.MaxNameLength(ctx) {
+	if uint64(len(name)) > k.GetParam(ctx, types.KeyMaxNameLength) {
 		return 0, types.ErrBadDataValue(
 			"AddDataSource: Name length (%d) exceeds the maximum length (%d).",
-			len(name), int(k.MaxNameLength(ctx)),
+			len(name), k.GetParam(ctx, types.KeyMaxNameLength),
 		)
 	}
-	if int64(len(description)) > k.MaxDescriptionLength(ctx) {
+	if uint64(len(description)) > k.GetParam(ctx, types.KeyMaxDescriptionLength) {
 		return 0, types.ErrBadDataValue(
 			"AddDataSource: Description length (%d) exceeds the maximum length (%d).",
-			len(description), int(k.MaxDescriptionLength(ctx)),
+			len(description), k.GetParam(ctx, types.KeyMaxDescriptionLength),
 		)
 	}
 
@@ -52,22 +52,22 @@ func (k Keeper) EditDataSource(
 		return types.ErrItemNotFound("EditDataSource: Unknown data source ID %d.", dataSourceID)
 	}
 
-	if int64(len(executable)) > k.MaxDataSourceExecutableSize(ctx) {
+	if uint64(len(executable)) > k.GetParam(ctx, types.KeyMaxDataSourceExecutableSize) {
 		return types.ErrBadDataValue(
 			"EditDataSource: Executable size (%d) exceeds the maximum size (%d).",
-			len(executable), int(k.MaxDataSourceExecutableSize(ctx)),
+			len(executable), k.GetParam(ctx, types.KeyMaxDataSourceExecutableSize),
 		)
 	}
-	if int64(len(name)) > k.MaxNameLength(ctx) {
+	if uint64(len(name)) > k.GetParam(ctx, types.KeyMaxNameLength) {
 		return types.ErrBadDataValue(
 			"EditDataSource: Name length (%d) exceeds the maximum length (%d).",
-			len(name), int(k.MaxNameLength(ctx)),
+			len(name), k.GetParam(ctx, types.KeyMaxNameLength),
 		)
 	}
-	if int64(len(description)) > k.MaxDescriptionLength(ctx) {
+	if uint64(len(description)) > k.GetParam(ctx, types.KeyMaxDescriptionLength) {
 		return types.ErrBadDataValue(
 			"EditDataSource: Description length (%d) exceeds the maximum length (%d).",
-			len(description), int(k.MaxDescriptionLength(ctx)),
+			len(description), k.GetParam(ctx, types.KeyMaxDescriptionLength),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/data_source_test.go
+++ b/chain/x/zoracle/internal/keeper/data_source_test.go
@@ -66,7 +66,7 @@ func TestAddTooLongDataSource(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Set MaxDataSourceExecutableSize to 20
-	keeper.SetMaxDataSourceExecutableSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, 20)
 
 	owner := sdk.AccAddress([]byte("owner"))
 	name := "data_source"
@@ -85,7 +85,7 @@ func TestAddTooLongDataSourceName(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Set MaxNameLength to 5
-	keeper.SetMaxNameLength(ctx, 5)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, 5)
 
 	owner := sdk.AccAddress([]byte("owner"))
 	tooLongName := "data_source"
@@ -104,7 +104,7 @@ func TestAddTooLongDataSourceDescription(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Set MaxDescriptionLength to 5
-	keeper.SetMaxDescriptionLength(ctx, 5)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, 5)
 
 	owner := sdk.AccAddress([]byte("owner"))
 	name := "data_source"
@@ -143,7 +143,7 @@ func TestEditTooLongDataSource(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	// Set MaxDataSourceExecutableSize to 20
-	keeper.SetMaxDataSourceExecutableSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, 20)
 	err := mockDataSource(ctx, keeper)
 	require.Nil(t, err)
 
@@ -161,7 +161,7 @@ func TestEditTooLongDataSourceName(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	//SetMaxNameLength to 20
-	keeper.SetMaxNameLength(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, 20)
 	err := mockDataSource(ctx, keeper)
 	require.Nil(t, err)
 
@@ -179,7 +179,7 @@ func TestEditTooLongDataSourceDescription(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	//Set MaxDescriptionLength to 20
-	keeper.SetMaxDescriptionLength(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, 20)
 	err := mockDataSource(ctx, keeper)
 	require.Nil(t, err)
 

--- a/chain/x/zoracle/internal/keeper/keeper.go
+++ b/chain/x/zoracle/internal/keeper/keeper.go
@@ -36,108 +36,30 @@ func ParamKeyTable() params.KeyTable {
 	return params.NewKeyTable().RegisterParamSet(&types.Params{})
 }
 
-func (keeper Keeper) MaxDataSourceExecutableSize(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxDataSourceExecutableSize, &res)
+// GetParam returns the parameter as specified by key as an uint64.
+func (keeper Keeper) GetParam(ctx sdk.Context, key []byte) (res uint64) {
+	keeper.ParamSpace.Get(ctx, key, &res)
 	return
 }
 
-func (keeper Keeper) SetMaxDataSourceExecutableSize(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxDataSourceExecutableSize, value)
-}
-
-func (keeper Keeper) MaxOracleScriptCodeSize(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxOracleScriptCodeSize, &res)
-	return
-}
-
-func (keeper Keeper) SetMaxOracleScriptCodeSize(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxOracleScriptCodeSize, value)
-}
-
-func (keeper Keeper) MaxCalldataSize(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxCalldataSize, &res)
-	return
-}
-
-func (keeper Keeper) SetMaxCalldataSize(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxCalldataSize, value)
-}
-
-func (keeper Keeper) MaxDataSourceCountPerRequest(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxDataSourceCountPerRequest, &res)
-	return
-}
-
-func (keeper Keeper) SetMaxDataSourceCountPerRequest(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxDataSourceCountPerRequest, value)
-}
-
-func (keeper Keeper) MaxRawDataReportSize(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxRawDataReportSize, &res)
-	return
-}
-
-func (keeper Keeper) SetMaxRawDataReportSize(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxRawDataReportSize, value)
-}
-
-func (keeper Keeper) MaxResultSize(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxResultSize, &res)
-	return
-}
-
-func (keeper Keeper) SetMaxResultSize(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxResultSize, value)
-}
-
-func (keeper Keeper) EndBlockExecuteGasLimit(ctx sdk.Context) (res uint64) {
-	keeper.ParamSpace.Get(ctx, types.KeyEndBlockExecuteGasLimit, &res)
-	return
-}
-
-func (keeper Keeper) SetEndBlockExecuteGasLimit(ctx sdk.Context, value uint64) {
-	keeper.ParamSpace.Set(ctx, types.KeyEndBlockExecuteGasLimit, value)
-}
-
-func (keeper Keeper) SetMaxNameLength(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxNameLength, value)
-}
-
-func (keeper Keeper) MaxNameLength(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxNameLength, &res)
-	return
-}
-func (keeper Keeper) MaxDescriptionLength(ctx sdk.Context) (res int64) {
-	keeper.ParamSpace.Get(ctx, types.KeyMaxDescriptionLength, &res)
-	return
-}
-
-func (keeper Keeper) SetMaxDescriptionLength(ctx sdk.Context, value int64) {
-	keeper.ParamSpace.Set(ctx, types.KeyMaxDescriptionLength, value)
-}
-
-func (keeper Keeper) GasPerRawDataRequestPerValidator(ctx sdk.Context) (res uint64) {
-	keeper.ParamSpace.Get(ctx, types.KeyGasPerRawDataRequestPerValidator, &res)
-	return
-}
-
-func (keeper Keeper) SetGasPerRawDataRequestPerValidator(ctx sdk.Context, value uint64) {
-	keeper.ParamSpace.Set(ctx, types.KeyGasPerRawDataRequestPerValidator, value)
+// SetParam saves the given key-value parameter to the store.
+func (keeper Keeper) SetParam(ctx sdk.Context, key []byte, value uint64) {
+	keeper.ParamSpace.Set(ctx, key, value)
 }
 
 // GetParams returns all current parameters as a types.Params instance.
 func (keeper Keeper) GetParams(ctx sdk.Context) types.Params {
 	return types.NewParams(
-		keeper.MaxDataSourceExecutableSize(ctx),
-		keeper.MaxOracleScriptCodeSize(ctx),
-		keeper.MaxCalldataSize(ctx),
-		keeper.MaxDataSourceCountPerRequest(ctx),
-		keeper.MaxRawDataReportSize(ctx),
-		keeper.MaxResultSize(ctx),
-		keeper.EndBlockExecuteGasLimit(ctx),
-		keeper.MaxNameLength(ctx),
-		keeper.MaxDescriptionLength(ctx),
-		keeper.GasPerRawDataRequestPerValidator(ctx),
+		keeper.GetParam(ctx, types.KeyMaxDataSourceExecutableSize),
+		keeper.GetParam(ctx, types.KeyMaxOracleScriptCodeSize),
+		keeper.GetParam(ctx, types.KeyMaxCalldataSize),
+		keeper.GetParam(ctx, types.KeyMaxDataSourceCountPerRequest),
+		keeper.GetParam(ctx, types.KeyMaxRawDataReportSize),
+		keeper.GetParam(ctx, types.KeyMaxResultSize),
+		keeper.GetParam(ctx, types.KeyEndBlockExecuteGasLimit),
+		keeper.GetParam(ctx, types.KeyMaxNameLength),
+		keeper.GetParam(ctx, types.KeyMaxDescriptionLength),
+		keeper.GetParam(ctx, types.KeyGasPerRawDataRequestPerValidator),
 	)
 }
 

--- a/chain/x/zoracle/internal/keeper/keeper_test.go
+++ b/chain/x/zoracle/internal/keeper/keeper_test.go
@@ -32,92 +32,92 @@ func TestGetNextRequestID(t *testing.T) {
 
 func TestGetSetMaxDataSourceExecutableSize(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxDataSourceExecutableSize(ctx, int64(1))
-	require.Equal(t, int64(1), keeper.MaxDataSourceExecutableSize(ctx))
-	keeper.SetMaxDataSourceExecutableSize(ctx, int64(2))
-	require.Equal(t, int64(2), keeper.MaxDataSourceExecutableSize(ctx))
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, 1)
+	require.Equal(t, uint64(1), keeper.GetParam(ctx, types.KeyMaxDataSourceExecutableSize))
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, 2)
+	require.Equal(t, uint64(2), keeper.GetParam(ctx, types.KeyMaxDataSourceExecutableSize))
 }
 
 func TestGetSetMaxOracleScriptCodeSize(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxOracleScriptCodeSize(ctx, int64(1))
-	require.Equal(t, int64(1), keeper.MaxOracleScriptCodeSize(ctx))
-	keeper.SetMaxOracleScriptCodeSize(ctx, int64(2))
-	require.Equal(t, int64(2), keeper.MaxOracleScriptCodeSize(ctx))
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, 1)
+	require.Equal(t, uint64(1), keeper.GetParam(ctx, types.KeyMaxOracleScriptCodeSize))
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, 2)
+	require.Equal(t, uint64(2), keeper.GetParam(ctx, types.KeyMaxOracleScriptCodeSize))
 }
 
 func TestGetSetMaxCalldataSize(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxCalldataSize(ctx, int64(1))
-	require.Equal(t, int64(1), keeper.MaxCalldataSize(ctx))
-	keeper.SetMaxCalldataSize(ctx, int64(2))
-	require.Equal(t, int64(2), keeper.MaxCalldataSize(ctx))
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 1)
+	require.Equal(t, uint64(1), keeper.GetParam(ctx, types.KeyMaxCalldataSize))
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 2)
+	require.Equal(t, uint64(2), keeper.GetParam(ctx, types.KeyMaxCalldataSize))
 }
 
 func TestGetSetMaxDataSourceCountPerRequest(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxDataSourceCountPerRequest(ctx, int64(1))
-	require.Equal(t, int64(1), keeper.MaxDataSourceCountPerRequest(ctx))
-	keeper.SetMaxDataSourceCountPerRequest(ctx, int64(2))
-	require.Equal(t, int64(2), keeper.MaxDataSourceCountPerRequest(ctx))
+	keeper.SetParam(ctx, types.KeyMaxDataSourceCountPerRequest, 1)
+	require.Equal(t, uint64(1), keeper.GetParam(ctx, types.KeyMaxDataSourceCountPerRequest))
+	keeper.SetParam(ctx, types.KeyMaxDataSourceCountPerRequest, 2)
+	require.Equal(t, uint64(2), keeper.GetParam(ctx, types.KeyMaxDataSourceCountPerRequest))
 }
 
 func TestGetSetMaxRawDataReportSize(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxRawDataReportSize(ctx, int64(1))
-	require.Equal(t, int64(1), keeper.MaxRawDataReportSize(ctx))
-	keeper.SetMaxRawDataReportSize(ctx, int64(2))
-	require.Equal(t, int64(2), keeper.MaxRawDataReportSize(ctx))
+	keeper.SetParam(ctx, types.KeyMaxRawDataReportSize, 1)
+	require.Equal(t, uint64(1), keeper.GetParam(ctx, types.KeyMaxRawDataReportSize))
+	keeper.SetParam(ctx, types.KeyMaxRawDataReportSize, 2)
+	require.Equal(t, uint64(2), keeper.GetParam(ctx, types.KeyMaxRawDataReportSize))
 }
 
 func TestGetSetMaxResultSize(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxResultSize(ctx, int64(1))
-	require.Equal(t, int64(1), keeper.MaxResultSize(ctx))
-	keeper.SetMaxResultSize(ctx, int64(2))
-	require.Equal(t, int64(2), keeper.MaxResultSize(ctx))
+	keeper.SetParam(ctx, types.KeyMaxResultSize, 1)
+	require.Equal(t, uint64(1), keeper.GetParam(ctx, types.KeyMaxResultSize))
+	keeper.SetParam(ctx, types.KeyMaxResultSize, 2)
+	require.Equal(t, uint64(2), keeper.GetParam(ctx, types.KeyMaxResultSize))
 }
 
 func TestGetSetEndBlockExecuteGasLimit(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetEndBlockExecuteGasLimit(ctx, uint64(3000))
-	require.Equal(t, uint64(3000), keeper.EndBlockExecuteGasLimit(ctx))
-	keeper.SetEndBlockExecuteGasLimit(ctx, uint64(5000))
-	require.Equal(t, uint64(5000), keeper.EndBlockExecuteGasLimit(ctx))
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, uint64(3000))
+	require.Equal(t, uint64(3000), keeper.GetParam(ctx, types.KeyEndBlockExecuteGasLimit))
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, uint64(5000))
+	require.Equal(t, uint64(5000), keeper.GetParam(ctx, types.KeyEndBlockExecuteGasLimit))
 }
 
 func TestGetSetGasPerRawDataRequestPerValidator(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, uint64(3000))
-	require.Equal(t, uint64(3000), keeper.GasPerRawDataRequestPerValidator(ctx))
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, uint64(5000))
-	require.Equal(t, uint64(5000), keeper.GasPerRawDataRequestPerValidator(ctx))
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, uint64(3000))
+	require.Equal(t, uint64(3000), keeper.GetParam(ctx, types.KeyGasPerRawDataRequestPerValidator))
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, uint64(5000))
+	require.Equal(t, uint64(5000), keeper.GetParam(ctx, types.KeyGasPerRawDataRequestPerValidator))
 }
 
 func TestGetSetParams(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
-	keeper.SetMaxDataSourceExecutableSize(ctx, int64(1))
-	keeper.SetMaxOracleScriptCodeSize(ctx, int64(1))
-	keeper.SetMaxCalldataSize(ctx, int64(1))
-	keeper.SetMaxDataSourceCountPerRequest(ctx, int64(1))
-	keeper.SetMaxRawDataReportSize(ctx, int64(1))
-	keeper.SetMaxResultSize(ctx, int64(1))
-	keeper.SetEndBlockExecuteGasLimit(ctx, uint64(200000))
-	keeper.SetMaxNameLength(ctx, int64(1))
-	keeper.SetMaxDescriptionLength(ctx, int64(1))
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, uint64(1000))
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, 1)
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, 1)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 1)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceCountPerRequest, 1)
+	keeper.SetParam(ctx, types.KeyMaxRawDataReportSize, 1)
+	keeper.SetParam(ctx, types.KeyMaxResultSize, 1)
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, 200000)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, 1)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, 1)
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, 1000)
 	require.Equal(t, types.NewParams(1, 1, 1, 1, 1, 1, 200000, 1, 1, 1000), keeper.GetParams(ctx))
 
-	keeper.SetMaxDataSourceExecutableSize(ctx, int64(2))
-	keeper.SetMaxOracleScriptCodeSize(ctx, int64(2))
-	keeper.SetMaxCalldataSize(ctx, int64(2))
-	keeper.SetMaxDataSourceCountPerRequest(ctx, int64(2))
-	keeper.SetMaxRawDataReportSize(ctx, int64(2))
-	keeper.SetMaxResultSize(ctx, int64(2))
-	keeper.SetEndBlockExecuteGasLimit(ctx, uint64(300000))
-	keeper.SetMaxNameLength(ctx, int64(2))
-	keeper.SetMaxDescriptionLength(ctx, int64(2))
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, uint64(2000))
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, 2)
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, 2)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 2)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceCountPerRequest, 2)
+	keeper.SetParam(ctx, types.KeyMaxRawDataReportSize, 2)
+	keeper.SetParam(ctx, types.KeyMaxResultSize, 2)
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, 300000)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, 2)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, 2)
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, 2000)
 	require.Equal(t, types.NewParams(2, 2, 2, 2, 2, 2, 300000, 2, 2, 2000), keeper.GetParams(ctx))
 }

--- a/chain/x/zoracle/internal/keeper/oracle_script.go
+++ b/chain/x/zoracle/internal/keeper/oracle_script.go
@@ -17,22 +17,22 @@ func (k Keeper) SetOracleScript(
 func (k Keeper) AddOracleScript(
 	ctx sdk.Context, owner sdk.AccAddress, name string, description string, code []byte,
 ) (types.OracleScriptID, sdk.Error) {
-	if int64(len(code)) > k.MaxOracleScriptCodeSize(ctx) {
+	if uint64(len(code)) > k.GetParam(ctx, types.KeyMaxOracleScriptCodeSize) {
 		return 0, types.ErrBadDataValue(
 			"AddOracleScript: Code size (%d) exceeds the maximum size (%d).",
-			len(code), int(k.MaxOracleScriptCodeSize(ctx)),
+			len(code), k.GetParam(ctx, types.KeyMaxOracleScriptCodeSize),
 		)
 	}
-	if int64(len(name)) > k.MaxNameLength(ctx) {
+	if uint64(len(name)) > k.GetParam(ctx, types.KeyMaxNameLength) {
 		return 0, types.ErrBadDataValue(
 			"AddOracleScript: Name length (%d) exceeds the maximum length (%d). 211",
-			len(name), int(k.MaxNameLength(ctx)),
+			len(name), k.GetParam(ctx, types.KeyMaxNameLength),
 		)
 	}
-	if int64(len(description)) > k.MaxDescriptionLength(ctx) {
+	if uint64(len(description)) > k.GetParam(ctx, types.KeyMaxDescriptionLength) {
 		return 0, types.ErrBadDataValue(
 			"AddOracleScript: Name length (%d) exceeds the maximum length (%d).",
-			len(name), int(k.MaxNameLength(ctx)),
+			len(name), k.GetParam(ctx, types.KeyMaxNameLength),
 		)
 	}
 
@@ -52,22 +52,22 @@ func (k Keeper) EditOracleScript(
 			"EditOracleScript: Unknown oracle script ID %d.", oracleScriptID,
 		)
 	}
-	if int64(len(code)) > k.MaxOracleScriptCodeSize(ctx) {
+	if uint64(len(code)) > k.GetParam(ctx, types.KeyMaxOracleScriptCodeSize) {
 		return types.ErrBadDataValue(
 			"EditDataSource: Code size (%d) exceeds the maximum size (%d).",
-			len(code), int(k.MaxOracleScriptCodeSize(ctx)),
+			len(code), k.GetParam(ctx, types.KeyMaxOracleScriptCodeSize),
 		)
 	}
-	if int64(len(name)) > k.MaxNameLength(ctx) {
+	if uint64(len(name)) > k.GetParam(ctx, types.KeyMaxNameLength) {
 		return types.ErrBadDataValue(
 			"EditOracleScript: Name length (%d) exceeds the maximum length (%d).",
-			len(name), int(k.MaxNameLength(ctx)),
+			len(name), k.GetParam(ctx, types.KeyMaxNameLength),
 		)
 	}
-	if int64(len(description)) > k.MaxDescriptionLength(ctx) {
+	if uint64(len(description)) > k.GetParam(ctx, types.KeyMaxDescriptionLength) {
 		return types.ErrBadDataValue(
 			"EditDataSource: Description length (%d) exceeds the maximum length (%d).",
-			len(description), int(k.MaxDescriptionLength(ctx)),
+			len(description), k.GetParam(ctx, types.KeyMaxDescriptionLength),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/oracle_script_test.go
+++ b/chain/x/zoracle/internal/keeper/oracle_script_test.go
@@ -61,7 +61,7 @@ func TestAddTooLongOracleScript(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Set MaxOracleScriptCodeSize to 20
-	keeper.SetMaxOracleScriptCodeSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, 20)
 
 	owner := sdk.AccAddress([]byte("owner"))
 	name := "oracle_script"
@@ -79,7 +79,7 @@ func TestAddTooLongOracleScriptName(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Set MaxNameLength to 5
-	keeper.SetMaxNameLength(ctx, 5)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, 5)
 
 	owner := sdk.AccAddress([]byte("owner"))
 	tooLongName := "oracle_script"
@@ -97,7 +97,7 @@ func TestAddTooLongOracleScriptDescription(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Set MaxNameLength to 5
-	keeper.SetMaxDescriptionLength(ctx, 5)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, 5)
 
 	owner := sdk.AccAddress([]byte("owner"))
 	name := "oracle_script"
@@ -133,7 +133,7 @@ func TestEditTooLongOracleScript(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	// Set MaxOracleScriptCodeSize to 20
-	keeper.SetMaxOracleScriptCodeSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, 20)
 	err := mockOracleScript(ctx, keeper)
 	require.Nil(t, err)
 
@@ -149,7 +149,7 @@ func TestEditOracleScriptTooLongName(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	// Set MaxOracleScriptCodeSize to 20
-	keeper.SetMaxNameLength(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, 20)
 	err := mockOracleScript(ctx, keeper)
 	require.Nil(t, err)
 
@@ -165,7 +165,7 @@ func TestEditOracleScriptTooLongDescription(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 
 	// Set MaxDescriptionLength to 11
-	keeper.SetMaxDescriptionLength(ctx, 11)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, 11)
 	err := mockOracleScript(ctx, keeper)
 	require.Nil(t, err)
 

--- a/chain/x/zoracle/internal/keeper/raw_request.go
+++ b/chain/x/zoracle/internal/keeper/raw_request.go
@@ -52,7 +52,7 @@ func (k Keeper) AddNewRawDataRequest(
 	if uint64(len(calldata)) > k.GetParam(ctx, types.KeyMaxCalldataSize) {
 		return types.ErrBadDataValue(
 			"AddNewRawDataRequest: Calldata size (%d) exceeds the maximum size (%d).",
-			len(calldata), int(k.GetParam(ctx, types.KeyMaxCalldataSize)),
+			len(calldata), k.GetParam(ctx, types.KeyMaxCalldataSize),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/raw_request.go
+++ b/chain/x/zoracle/internal/keeper/raw_request.go
@@ -49,10 +49,10 @@ func (k Keeper) AddNewRawDataRequest(
 	ctx sdk.Context, requestID types.RequestID, externalID types.ExternalID,
 	dataSourceID types.DataSourceID, calldata []byte,
 ) sdk.Error {
-	if int64(len(calldata)) > k.MaxCalldataSize(ctx) {
+	if uint64(len(calldata)) > k.GetParam(ctx, types.KeyMaxCalldataSize) {
 		return types.ErrBadDataValue(
 			"AddNewRawDataRequest: Calldata size (%d) exceeds the maximum size (%d).",
-			len(calldata), int(k.MaxCalldataSize(ctx)),
+			len(calldata), int(k.GetParam(ctx, types.KeyMaxCalldataSize)),
 		)
 	}
 
@@ -75,7 +75,7 @@ func (k Keeper) AddNewRawDataRequest(
 	}
 
 	ctx.GasMeter().ConsumeGas(
-		k.GasPerRawDataRequestPerValidator(ctx)*uint64(len(request.RequestedValidators)),
+		k.GetParam(ctx, types.KeyGasPerRawDataRequestPerValidator)*uint64(len(request.RequestedValidators)),
 		"RawDataRequest",
 	)
 	k.SetRawDataRequest(

--- a/chain/x/zoracle/internal/keeper/raw_request_test.go
+++ b/chain/x/zoracle/internal/keeper/raw_request_test.go
@@ -80,7 +80,7 @@ func TestGasConsumeByAddNewRawDataRequest(t *testing.T) {
 	request := newDefaultRequest()
 
 	// Set GasPerRawDataRequestPerValidator to 10000
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, 10000)
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, 10000)
 	keeper.SetRequest(ctx, 1, request)
 
 	dataSource := types.NewDataSource(
@@ -99,7 +99,7 @@ func TestGasConsumeByAddNewRawDataRequest(t *testing.T) {
 	gasUsed := ctx.GasMeter().GasConsumed() - beforeGas
 
 	// Set GasPerRawDataRequestPerValidator to 25000
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, 25000)
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, 25000)
 	keeper.SetRequest(ctx, 2, request)
 	beforeGas = ctx.GasMeter().GasConsumed()
 	err = keeper.AddNewRawDataRequest(ctx, 2, 42, 1, []byte("calldata1"))

--- a/chain/x/zoracle/internal/keeper/report.go
+++ b/chain/x/zoracle/internal/keeper/report.go
@@ -80,10 +80,10 @@ func (k Keeper) AddReport(
 				requestID, rawReport.ExternalDataID,
 			)
 		}
-		if int64(len(rawReport.Data)) > k.MaxRawDataReportSize(ctx) {
+		if uint64(len(rawReport.Data)) > k.GetParam(ctx, types.KeyMaxRawDataReportSize) {
 			return types.ErrBadDataValue(
 				"AddReport: RequestID %d: Raw report data size (%d) exceeds the limit (%d).",
-				requestID, len(rawReport.Data), k.MaxRawDataReportSize(ctx),
+				requestID, len(rawReport.Data), k.GetParam(ctx, types.KeyMaxRawDataReportSize),
 			)
 		}
 		k.SetRawDataReport(

--- a/chain/x/zoracle/internal/keeper/report_test.go
+++ b/chain/x/zoracle/internal/keeper/report_test.go
@@ -208,20 +208,20 @@ func TestAddNewRawDataRequestCallDataSizeTooBig(t *testing.T) {
 
 	// Set MaxCalldataSize to 0
 	// AddNewRawDataRequest should fail because size of "calldata" is > 0
-	keeper.SetMaxCalldataSize(ctx, 0)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 0)
 	err := keeper.AddNewRawDataRequest(ctx, 1, 1, 1, []byte("calldata"))
 	require.NotNil(t, err)
 
 	// Set MaxCalldataSize to 20
 	// AddNewRawDataRequest should pass because size of "calldata" is < 20
-	keeper.SetMaxCalldataSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 20)
 	err = keeper.AddNewRawDataRequest(ctx, 1, 1, 1, []byte("calldata"))
 	require.Nil(t, err)
 }
 
 func TestAddReportReportSizeExceedMaxRawDataReportSize(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
-	keeper.SetMaxRawDataReportSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxRawDataReportSize, 20)
 
 	request := newDefaultRequest()
 	keeper.SetRequest(ctx, 1, request)

--- a/chain/x/zoracle/internal/keeper/request.go
+++ b/chain/x/zoracle/internal/keeper/request.go
@@ -33,10 +33,10 @@ func (k Keeper) AddRequest(
 		return 0, types.ErrItemNotFound("AddRequest: Unknown oracle script ID %d.", oracleScriptID)
 	}
 
-	if int64(len(calldata)) > k.MaxCalldataSize(ctx) {
+	if uint64(len(calldata)) > k.GetParam(ctx, types.KeyMaxCalldataSize) {
 		return 0, types.ErrBadDataValue(
 			"AddRequest: Calldata size (%d) exceeds the maximum size (%d).",
-			len(calldata), int(k.MaxCalldataSize(ctx)),
+			len(calldata), int(k.GetParam(ctx, types.KeyMaxCalldataSize)),
 		)
 	}
 
@@ -54,10 +54,10 @@ func (k Keeper) AddRequest(
 	}
 
 	ctx.GasMeter().ConsumeGas(executeGas, "ExecuteGas")
-	if executeGas > k.EndBlockExecuteGasLimit(ctx) {
+	if executeGas > k.GetParam(ctx, types.KeyEndBlockExecuteGasLimit) {
 		return 0, types.ErrBadDataValue(
 			"AddRequest: Execute gas (%d) exceeds the maximum limit (%d).",
-			executeGas, k.EndBlockExecuteGasLimit(ctx),
+			executeGas, k.GetParam(ctx, types.KeyEndBlockExecuteGasLimit),
 		)
 	}
 
@@ -74,10 +74,10 @@ func (k Keeper) AddRequest(
 // allowed value, as specified by `MaxDataSourceCountPerRequest` parameter.
 func (k Keeper) ValidateDataSourceCount(ctx sdk.Context, id types.RequestID) sdk.Error {
 	dataSourceCount := k.GetRawDataRequestCount(ctx, id)
-	if dataSourceCount > k.MaxDataSourceCountPerRequest(ctx) {
+	if uint64(dataSourceCount) > k.GetParam(ctx, types.KeyMaxDataSourceCountPerRequest) {
 		return types.ErrBadDataValue(
 			"ValidateDataSourceCount: Data source count (%d) exceeds the limit (%d).",
-			dataSourceCount, k.MaxDataSourceCountPerRequest(ctx),
+			dataSourceCount, k.GetParam(ctx, types.KeyMaxDataSourceCountPerRequest),
 		)
 	}
 	return nil

--- a/chain/x/zoracle/internal/keeper/request.go
+++ b/chain/x/zoracle/internal/keeper/request.go
@@ -36,7 +36,7 @@ func (k Keeper) AddRequest(
 	if uint64(len(calldata)) > k.GetParam(ctx, types.KeyMaxCalldataSize) {
 		return 0, types.ErrBadDataValue(
 			"AddRequest: Calldata size (%d) exceeds the maximum size (%d).",
-			len(calldata), int(k.GetParam(ctx, types.KeyMaxCalldataSize)),
+			len(calldata), k.GetParam(ctx, types.KeyMaxCalldataSize),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/request_test.go
+++ b/chain/x/zoracle/internal/keeper/request_test.go
@@ -90,13 +90,13 @@ func TestRequestCallDataSizeTooBig(t *testing.T) {
 	)
 
 	// Set MaxCalldataSize to 0
-	keeper.SetMaxCalldataSize(ctx, 0)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 0)
 	// Should fail because size of "calldata" is > 0
 	_, err := keeper.AddRequest(ctx, 1, []byte("calldata"), 2, 2, 100, 20000)
 	require.NotNil(t, err)
 
 	// Set MaxCalldataSize to 20
-	keeper.SetMaxCalldataSize(ctx, 20)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, 20)
 	// Should pass because size of "calldata" is < 20
 	_, err = keeper.AddRequest(ctx, 1, []byte("calldata"), 2, 2, 100, 20000)
 	require.Nil(t, err)
@@ -122,13 +122,13 @@ func TestRequestExceedEndBlockExecuteGasLimit(t *testing.T) {
 	)
 
 	// Set EndBlockExecuteGasLimit to 10000
-	keeper.SetEndBlockExecuteGasLimit(ctx, 10000)
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, 10000)
 	// Should fail because required execute gas is > 10000
 	_, err := keeper.AddRequest(ctx, 1, []byte("calldata"), 2, 2, 100, 20000)
 	require.NotNil(t, err)
 
 	// Set EndBlockExecuteGasLimit to 30000
-	keeper.SetEndBlockExecuteGasLimit(ctx, 30000)
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, 30000)
 	// Should fail because required execute gas is < 30000
 	_, err = keeper.AddRequest(ctx, 1, []byte("calldata"), 2, 2, 100, 20000)
 	require.Nil(t, err)
@@ -266,7 +266,7 @@ func TestHasToPutInPendingList(t *testing.T) {
 func TestValidateDataSourceCount(t *testing.T) {
 	ctx, keeper := CreateTestInput(t, false)
 	// Set MaxDataSourceCountPerRequest to 3
-	keeper.SetMaxDataSourceCountPerRequest(ctx, 3)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceCountPerRequest, 3)
 
 	request := newDefaultRequest()
 	keeper.SetRequest(ctx, 1, request)

--- a/chain/x/zoracle/internal/keeper/result.go
+++ b/chain/x/zoracle/internal/keeper/result.go
@@ -13,7 +13,7 @@ func (k Keeper) AddResult(
 	if uint64(len(result)) > k.GetParam(ctx, types.KeyMaxResultSize) {
 		return types.ErrBadDataValue(
 			"AddResult: Result size (%d) exceeds the maximum size (%d).",
-			len(result), int(k.GetParam(ctx, types.KeyMaxResultSize)),
+			len(result), k.GetParam(ctx, types.KeyMaxResultSize),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/result.go
+++ b/chain/x/zoracle/internal/keeper/result.go
@@ -10,10 +10,10 @@ func (k Keeper) AddResult(
 	ctx sdk.Context, requestID types.RequestID, oracleScriptID types.OracleScriptID,
 	calldata []byte, result []byte,
 ) sdk.Error {
-	if int64(len(result)) > k.MaxResultSize(ctx) {
+	if uint64(len(result)) > k.GetParam(ctx, types.KeyMaxResultSize) {
 		return types.ErrBadDataValue(
 			"AddResult: Result size (%d) exceeds the maximum size (%d).",
-			len(result), int(k.MaxResultSize(ctx)),
+			len(result), int(k.GetParam(ctx, types.KeyMaxResultSize)),
 		)
 	}
 

--- a/chain/x/zoracle/internal/keeper/result_test.go
+++ b/chain/x/zoracle/internal/keeper/result_test.go
@@ -65,7 +65,7 @@ func TestAddResultFailWithExceedResultSize(t *testing.T) {
 	_, err := keeper.GetResult(ctx, 1, 1, []byte("calldata"))
 	require.NotNil(t, err)
 
-	keeper.SetMaxResultSize(ctx, int64(1))
+	keeper.SetParam(ctx, types.KeyMaxResultSize, 1)
 	err = keeper.AddResult(ctx, 1, 1, []byte("calldata"), []byte("result"))
 	require.NotNil(t, err)
 }

--- a/chain/x/zoracle/internal/keeper/test_common.go
+++ b/chain/x/zoracle/internal/keeper/test_common.go
@@ -139,16 +139,16 @@ func CreateTestInput(t *testing.T, isCheckTx bool) (sdk.Context, Keeper) {
 	require.Equal(t, account, accountKeeper.GetAccount(ctx, addr))
 
 	// Set default parameter
-	keeper.SetMaxDataSourceExecutableSize(ctx, types.DefaultMaxDataSourceExecutableSize)
-	keeper.SetMaxOracleScriptCodeSize(ctx, types.DefaultMaxOracleScriptCodeSize)
-	keeper.SetMaxCalldataSize(ctx, types.DefaultMaxCalldataSize)
-	keeper.SetMaxDataSourceCountPerRequest(ctx, types.DefaultMaxDataSourceCountPerRequest)
-	keeper.SetMaxRawDataReportSize(ctx, types.DefaultMaxRawDataReportSize)
-	keeper.SetMaxResultSize(ctx, types.DefaultMaxResultSize)
-	keeper.SetEndBlockExecuteGasLimit(ctx, types.DefaultEndBlockExecuteGasLimit)
-	keeper.SetMaxNameLength(ctx, types.DefaultMaxNameLength)
-	keeper.SetMaxDescriptionLength(ctx, types.DefaultDescriptionLength)
-	keeper.SetGasPerRawDataRequestPerValidator(ctx, types.DefaultGasPerRawDataRequestPerValidator)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceExecutableSize, types.DefaultMaxDataSourceExecutableSize)
+	keeper.SetParam(ctx, types.KeyMaxOracleScriptCodeSize, types.DefaultMaxOracleScriptCodeSize)
+	keeper.SetParam(ctx, types.KeyMaxCalldataSize, types.DefaultMaxCalldataSize)
+	keeper.SetParam(ctx, types.KeyMaxDataSourceCountPerRequest, types.DefaultMaxDataSourceCountPerRequest)
+	keeper.SetParam(ctx, types.KeyMaxRawDataReportSize, types.DefaultMaxRawDataReportSize)
+	keeper.SetParam(ctx, types.KeyMaxResultSize, types.DefaultMaxResultSize)
+	keeper.SetParam(ctx, types.KeyEndBlockExecuteGasLimit, types.DefaultEndBlockExecuteGasLimit)
+	keeper.SetParam(ctx, types.KeyMaxNameLength, types.DefaultMaxNameLength)
+	keeper.SetParam(ctx, types.KeyMaxDescriptionLength, types.DefaultDescriptionLength)
+	keeper.SetParam(ctx, types.KeyGasPerRawDataRequestPerValidator, types.DefaultGasPerRawDataRequestPerValidator)
 
 	return ctx, keeper
 }

--- a/chain/x/zoracle/internal/types/params.go
+++ b/chain/x/zoracle/internal/types/params.go
@@ -12,27 +12,27 @@ const (
 
 	// The maximum size of data source executable size, in bytes.
 	// Default value is set to 10 kB.
-	DefaultMaxDataSourceExecutableSize = int64(10 * 1024)
+	DefaultMaxDataSourceExecutableSize = uint64(10 * 1024)
 
 	// The maximum size of Owasm code, in bytes.
 	// Default value is set to 500 kB.
-	DefaultMaxOracleScriptCodeSize = int64(500 * 1024)
+	DefaultMaxOracleScriptCodeSize = uint64(500 * 1024)
 
 	// The maximum size of calldata when invoking for oracle scripts or data sources.
 	// Default value is set 1 kB.
-	DefaultMaxCalldataSize = int64(1 * 1024)
+	DefaultMaxCalldataSize = uint64(1 * 1024)
 
 	// The maximum number of data sources a request can make.
 	// Default value is set to 16.
-	DefaultMaxDataSourceCountPerRequest = int64(16)
+	DefaultMaxDataSourceCountPerRequest = uint64(16)
 
 	// The maximum size of raw data report per data source.
 	// Default value is set to 1 kB.
-	DefaultMaxRawDataReportSize = int64(1 * 1024)
+	DefaultMaxRawDataReportSize = uint64(1 * 1024)
 
 	// The maximum size of result after execution.
 	// Default value is set 1 kB.
-	DefaultMaxResultSize = int64(1 * 1024)
+	DefaultMaxResultSize = uint64(1 * 1024)
 
 	// The maximum gas that can be used to resolve requests at endblock time
 	// Default value is 1000000
@@ -40,11 +40,11 @@ const (
 
 	// The maximum size of name length.
 	// Default value is 280
-	DefaultMaxNameLength = int64(280)
+	DefaultMaxNameLength = uint64(280)
 
 	// The maximum size of description length.
 	// Default value 4096
-	DefaultDescriptionLength = int64(4096)
+	DefaultDescriptionLength = uint64(4096)
 
 	// Gas cost per validator for each raw data request.
 	DefaultGasPerRawDataRequestPerValidator = uint64(25000)
@@ -66,29 +66,29 @@ var (
 
 // Params - used for initializing default parameter for zoracle at genesis.
 type Params struct {
-	MaxDataSourceExecutableSize      int64  `json:"max_data_source_executable_size" yaml:"max_data_source_executable_size"`
-	MaxOracleScriptCodeSize          int64  `json:"max_oracle_script_code_size" yaml:"max_oracle_script_code_size"`
-	MaxCalldataSize                  int64  `json:"max_calldata_size" yaml:"max_calldata_size"`
-	MaxDataSourceCountPerRequest     int64  `json:"max_data_source_count_per_request" yaml:"max_data_source_count_per_request"`
-	MaxRawDataReportSize             int64  `json:"max_raw_data_report_size" yaml:"max_raw_data_report_size"`
-	MaxResultSize                    int64  `json:"max_result_size" yaml:"max_result_size"`
+	MaxDataSourceExecutableSize      uint64 `json:"max_data_source_executable_size" yaml:"max_data_source_executable_size"`
+	MaxOracleScriptCodeSize          uint64 `json:"max_oracle_script_code_size" yaml:"max_oracle_script_code_size"`
+	MaxCalldataSize                  uint64 `json:"max_calldata_size" yaml:"max_calldata_size"`
+	MaxDataSourceCountPerRequest     uint64 `json:"max_data_source_count_per_request" yaml:"max_data_source_count_per_request"`
+	MaxRawDataReportSize             uint64 `json:"max_raw_data_report_size" yaml:"max_raw_data_report_size"`
+	MaxResultSize                    uint64 `json:"max_result_size" yaml:"max_result_size"`
 	EndBlockExecuteGasLimit          uint64 `json:"end_block_execute_gas_limit" yaml:"end_block_execute_gas_limit"`
-	MaxNameLength                    int64  `json:"max_name_length" yaml:"max_name_length"`
-	MaxDescriptionLength             int64  `json:"max_description_length" yaml:"max_description_length"`
+	MaxNameLength                    uint64 `json:"max_name_length" yaml:"max_name_length"`
+	MaxDescriptionLength             uint64 `json:"max_description_length" yaml:"max_description_length"`
 	GasPerRawDataRequestPerValidator uint64 `json:"gas_per_raw_data_request" yaml:"gas_per_raw_data_request"`
 }
 
 // NewParams creates a new Params object.
 func NewParams(
-	maxDataSourceExecutableSize int64,
-	maxOracleScriptCodeSize int64,
-	maxCalldataSize int64,
-	maxDataSourceCountPerRequest int64,
-	maxRawDataReportSize int64,
-	maxResultSize int64,
+	maxDataSourceExecutableSize uint64,
+	maxOracleScriptCodeSize uint64,
+	maxCalldataSize uint64,
+	maxDataSourceCountPerRequest uint64,
+	maxRawDataReportSize uint64,
+	maxResultSize uint64,
 	endBlockExecuteGasLimit uint64,
-	maxNameLength int64,
-	maxDescriptionLength int64,
+	maxNameLength uint64,
+	maxDescriptionLength uint64,
 	gasPerRawDataRequestPerValidator uint64,
 ) Params {
 	return Params{


### PR DESCRIPTION
All parameters are in the form of Max... or Gas..., so it makes sense to make all of them `uint64`. It also makes sense to just have one function to get/set, rather have the number of functions scales according to number of params.