### PR TITLE
chain: Recover panic from VM.Run 

### DIFF
--- a/chain/owasm/execute.go
+++ b/chain/owasm/execute.go
@@ -1,6 +1,7 @@
 package owasm
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/perlin-network/life/exec"
@@ -36,6 +37,20 @@ func Execute(
 	if !ok {
 		return nil, 0, fmt.Errorf("Execute: invalid owasm entry: %s", entry)
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("Unknown panic")
+			}
+			result = nil
+			gasUsed = 0
+		}
+	}()
 	_, err = vm.Run(int(entryID))
 	return resolver.result, vm.Gas, err
 }

--- a/chain/owasm/execute.go
+++ b/chain/owasm/execute.go
@@ -46,6 +46,8 @@ func Execute(
 				err = x
 			default:
 				err = errors.New("Unknown panic")
+				// TODO: Find a better way to handle unknown panic type
+				fmt.Println(x)
 			}
 			result = nil
 			gasUsed = 0

--- a/chain/owasm/execute_test.go
+++ b/chain/owasm/execute_test.go
@@ -50,7 +50,7 @@ func TestExecuteEndToEnd(t *testing.T) {
 	require.Nil(t, err)
 	env := &mockExecEnv{
 		externalDataResults:               [][][]byte{nil, {[]byte("RETURN_DATA")}},
-		requestExternalDataResultsCounter: [][]int64{nil, []int64{0}},
+		requestExternalDataResultsCounter: [][]int64{nil, {0}},
 		maximumResultSize:                 1024,
 		maximumCalldataOfDataSourceSize:   1024,
 	}
@@ -124,7 +124,7 @@ func TestExecuteInvalidGetMaximumResultSize(t *testing.T) {
 	require.Nil(t, err)
 	env := &mockExecEnv{
 		externalDataResults:               [][][]byte{nil, {[]byte("RETURN_DATA")}},
-		requestExternalDataResultsCounter: [][]int64{nil, []int64{0}},
+		requestExternalDataResultsCounter: [][]int64{nil, {0}},
 		maximumResultSize:                 10,
 	}
 
@@ -134,7 +134,7 @@ func TestExecuteInvalidGetMaximumResultSize(t *testing.T) {
 
 	env2 := &mockExecEnv{
 		externalDataResults:               [][][]byte{nil, {[]byte("RETURN_DATA")}},
-		requestExternalDataResultsCounter: [][]int64{nil, []int64{0}},
+		requestExternalDataResultsCounter: [][]int64{nil, {0}},
 		maximumResultSize:                 11,
 	}
 	// It should return "RETURN_DATA" and not return error.
@@ -144,3 +144,16 @@ func TestExecuteInvalidGetMaximumResultSize(t *testing.T) {
 }
 
 // TODO: Add more tests for MaxTableSize, MaxValueSlots and MaxCallStackDepth.
+
+func TestNotPanicFromWasm(t *testing.T) {
+	code, err := ioutil.ReadFile("./res/wrong_args.wasm")
+	require.Nil(t, err)
+	env := &mockExecEnv{
+		requestExternalDataResultsCounter: [][]int64{nil, {0}},
+		maximumResultSize:                 1024,
+		maximumCalldataOfDataSourceSize:   1024,
+	}
+
+	_, _, err = Execute(env, code, "prepare", []byte{}, 10000)
+	require.EqualError(t, err, "param count mismatch")
+}

--- a/owasm/Cargo.toml
+++ b/owasm/Cargo.toml
@@ -23,4 +23,5 @@ members = [
     "chaintests/get_env",
     "chaintests/gold_price",
     "chaindebugtests/allocate",
+    "chaindebugtests/wrong_args",
 ]

--- a/owasm/chaindebugtests/wrong_args/Cargo.toml
+++ b/owasm/chaindebugtests/wrong_args/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wrong_args"
+version = "0.1.0"
+authors = ["Band Protocol <dev@bandprotocol.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+owasm = { path = "../.." }
+borsh = "0.3.0"

--- a/owasm/chaindebugtests/wrong_args/src/lib.rs
+++ b/owasm/chaindebugtests/wrong_args/src/lib.rs
@@ -1,0 +1,39 @@
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use owasm::{execute_entry_point, oei};
+
+#[derive(BorshDeserialize, BorshSchema)]
+struct Input {
+    _unused: u8,
+}
+
+#[derive(BorshSerialize, BorshSchema)]
+struct Output {
+    result: String,
+}
+
+// Expect fail when prepare
+#[no_mangle]
+fn prepare(_input: Input) {
+    oei::request_external_data(1, 1, "Hello world".as_bytes());
+}
+
+fn execute_impl(_input: Input) -> Output {
+    Output { result: String::from("Yeah") }
+}
+
+// prepare_entry_point!(prepare_impl);
+execute_entry_point!(execute_impl);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::*;
+
+    #[test]
+    fn test_get_schema() {
+        let mut schema = HashMap::new();
+        Input::add_rec_type_definitions(&mut schema);
+        Output::add_rec_type_definitions(&mut schema);
+        println!("{:?}", schema);
+    }
+}


### PR DESCRIPTION
fixed #1377 

This is a result when request on bad oracle script
```
{
  "jsonrpc": "2.0",
  "id": -1,
  "result": {
    "hash": "394D9DD256F17D6C4234F4B118AC626C78624A0BE84B794AA5D27D9C88B9D6F5",
    "height": "39",
    "index": 0,
    "tx_result": {
      "code": 7,
      "data": null,
      "log": "failed to execute message; message index: 0: param count mismatch: bad wasm execution",
      "info": "",
      "gasWanted": "1000000",
      "gasUsed": "419897",
      "events": [],
      "codespace": "oracle"
    },
    "tx": "KCgWqQoqQnCONAgDEgEDGAEgASoFdGVzdDIyFN0+AvKRiDpO1BGaSf1z4gWDa6MlEgQQwIQ9GmoKJuta6YchA6rU4D6xY4ibvdSDdg8iLDSVF73O6ZB/vUH6iJsNRNqYEkDXFTv9NkZvIzK41s8jE5llt5JFf43PPwVTSWHBp8R0+kFcTy4UPnr/wb8C3l6oQGCoJwVSYjubWccOUnxcivGj"
  }
}
```