### PR TITLE
cacher: Add index to block timestamp

### DIFF
--- a/chain/db/table.go
+++ b/chain/db/table.go
@@ -11,7 +11,7 @@ type Metadata struct {
 
 type Block struct {
 	Height    int64  `gorm:"primary_key;auto_increment:false"`
-	Timestamp int64  `gorm:"not null"`
+	Timestamp int64  `gorm:"not null;index"`
 	Proposer  string `gorm:"not null"`
 	BlockHash []byte `gorm:"not null"`
 }


### PR DESCRIPTION
This makes getting average block time query 1000x time faster.
```
subscription AvgDayBlocksCount {
  blocks_aggregate(where: {timestamp: {_lte: "1588569460000", _gte: "1588483060000"}}) {
    aggregate {
      count
      max {
        timestamp
      }
      min {
        timestamp
      }
    }
  }
}```