### PR TITLE
chain: Refactor SendOracleResponse out and improve request ibc flow

### DIFF
--- a/chain/x/oracle/endblock.go
+++ b/chain/x/oracle/endblock.go
@@ -1,6 +1,8 @@
 package oracle
 
 import (
+	"fmt"
+
 	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -17,7 +19,10 @@ func resolveRequest(ctx sdk.Context, k Keeper, reqID types.RequestID) {
 
 	var res types.OracleResponsePacketData
 	if err != nil {
-		res = k.ResolveRequest(ctx, reqID, types.Failure, []byte(err.Error()))
+		k.Logger(ctx).Info(fmt.Sprintf(
+			"failed to execute request id: %d with error: %s", reqID, err.Error(),
+		))
+		res = k.ResolveRequest(ctx, reqID, types.Failure, nil)
 	} else {
 		res = k.ResolveRequest(ctx, reqID, types.Success, result)
 	}

--- a/chain/x/oracle/endblock.go
+++ b/chain/x/oracle/endblock.go
@@ -14,13 +14,16 @@ func resolveRequest(ctx sdk.Context, k Keeper, reqID types.RequestID) {
 	script := k.MustGetOracleScript(ctx, req.OracleScriptID)
 	executeGas := k.GetParam(ctx, KeyExecuteGas)
 	result, _, err := k.OwasmExecute(env, script.Code, "execute", req.Calldata, executeGas)
-	var resolveStatus types.ResolveStatus
+
+	var res types.OracleResponsePacketData
 	if err != nil {
-		resolveStatus = types.Failure
+		res = k.ResolveRequest(ctx, reqID, types.Failure, []byte(err.Error()))
 	} else {
-		resolveStatus = types.Success
+		res = k.ResolveRequest(ctx, reqID, types.Success, result)
 	}
-	k.ProcessOracleResponse(ctx, reqID, resolveStatus, result)
+	if req.IBC != nil {
+		k.SendOracleResponse(ctx, req.IBC.SourcePort, req.IBC.SourceChannel, res)
+	}
 }
 
 // handleEndBlock cleans up the state during end block. See comment in the implementation!

--- a/chain/x/oracle/exec_env_test.go
+++ b/chain/x/oracle/exec_env_test.go
@@ -19,7 +19,7 @@ func TestNewExecEnv(t *testing.T) {
 	})
 
 	keeper.SetRequest(ctx, 1, types.NewRequest(
-		1, []byte("calldata"), []sdk.ValAddress{sdk.ValAddress([]byte("val1"))}, 1, 0, 0, "clientID",
+		1, []byte("calldata"), []sdk.ValAddress{sdk.ValAddress([]byte("val1"))}, 1, 0, 0, "clientID", nil,
 	))
 
 	_ = NewExecEnv(ctx, keeper, keeper.MustGetRequest(ctx, 1))
@@ -30,7 +30,7 @@ func TestGetRequestedValidatorCount(t *testing.T) {
 	keeper.SetRequest(ctx, 1, types.NewRequest(
 		1, []byte("calldata"),
 		[]sdk.ValAddress{sdk.ValAddress([]byte("val1")), sdk.ValAddress([]byte("val2"))},
-		1, 0, 0, "clientID",
+		1, 0, 0, "clientID", nil,
 	))
 
 	env := NewExecEnv(ctx, keeper, keeper.MustGetRequest(ctx, 1))
@@ -47,7 +47,7 @@ func TestGetSufficientValidatorCount(t *testing.T) {
 			sdk.ValAddress([]byte("val3")),
 			sdk.ValAddress([]byte("val4")),
 		},
-		3, 0, 0, "clientID",
+		3, 0, 0, "clientID", nil,
 	))
 
 	env := NewExecEnv(ctx, keeper, keeper.MustGetRequest(ctx, 1))
@@ -76,7 +76,7 @@ func TestGetPrepareBlockTime(t *testing.T) {
 	ctx, keeper := keep.CreateTestInput(t, false)
 	keeper.SetRequest(ctx, 1, types.NewRequest(
 		1, []byte("calldata"), []sdk.ValAddress{sdk.ValAddress([]byte("val1"))},
-		1, 20, 1581589790, "clientID",
+		1, 20, 1581589790, "clientID", nil,
 	))
 
 	env := NewExecEnv(ctx, keeper, keeper.MustGetRequest(ctx, 1))
@@ -87,7 +87,7 @@ func TestGetAggregateBlockTime(t *testing.T) {
 	ctx, keeper := keep.CreateTestInput(t, false)
 	keeper.SetRequest(ctx, 1, types.NewRequest(
 		1, []byte("calldata"), []sdk.ValAddress{sdk.ValAddress([]byte("val1"))},
-		1, 0, 0, "clientID",
+		1, 0, 0, "clientID", nil,
 	))
 
 	ctx = ctx.WithBlockTime(time.Unix(int64(1581589790), 0))
@@ -125,7 +125,7 @@ func TestGetValidatorPubKey(t *testing.T) {
 	)
 	keeper.SetRequest(ctx, 1, types.NewRequest(
 		1, []byte("calldata"), []sdk.ValAddress{validatorAddress1, validatorAddress2},
-		1, 0, 0, "clientID",
+		1, 0, 0, "clientID", nil,
 	))
 
 	env := NewExecEnv(ctx, keeper, keeper.MustGetRequest(ctx, 1))
@@ -150,7 +150,7 @@ func TestRequestExternalData(t *testing.T) {
 	// Set Request
 	keeper.SetRequest(ctx, 1, types.NewRequest(
 		1, []byte("calldata"), []sdk.ValAddress{sdk.ValAddress([]byte("val1"))},
-		1, 0, 0, "clientID",
+		1, 0, 0, "clientID", nil,
 	))
 
 	// Set Datasource
@@ -180,7 +180,7 @@ func TestRequestExternalDataExceedMaxRawRequestCount(t *testing.T) {
 	// Set Request
 	keeper.SetRequest(ctx, 1, types.NewRequest(
 		1, []byte("calldata"), []sdk.ValAddress{sdk.ValAddress([]byte("val1"))},
-		1, 0, 0, "clientID",
+		1, 0, 0, "clientID", nil,
 	))
 
 	// Set Datasource

--- a/chain/x/oracle/handler.go
+++ b/chain/x/oracle/handler.go
@@ -114,7 +114,7 @@ func handleMsgRequestData(ctx sdk.Context, k Keeper, m MsgRequestData) (*sdk.Res
 
 	req := types.NewRequest(
 		m.OracleScriptID, m.Calldata, validators, m.SufficientValidatorCount,
-		ctx.BlockHeight(), ctx.BlockTime().Unix(), m.ClientID,
+		ctx.BlockHeight(), ctx.BlockTime().Unix(), m.ClientID, nil,
 	)
 	return prepareRequest(ctx, k, m, req)
 }
@@ -125,9 +125,10 @@ func handleMsgRequestDataIBC(ctx sdk.Context, k Keeper, m MsgRequestData, source
 		return nil, err
 	}
 
-	req := types.NewRequestWithRequestIBC(
+	req := types.NewRequest(
 		m.OracleScriptID, m.Calldata, validators, m.SufficientValidatorCount,
-		ctx.BlockHeight(), ctx.BlockTime().Unix(), m.ClientID, sourcePort, sourceChannel,
+		ctx.BlockHeight(), ctx.BlockTime().Unix(), m.ClientID,
+		&types.RequestIBC{sourcePort, sourceChannel},
 	)
 
 	return prepareRequest(ctx, k, m, req)

--- a/chain/x/oracle/handler_test.go
+++ b/chain/x/oracle/handler_test.go
@@ -231,7 +231,7 @@ func TestRequestSuccess(t *testing.T) {
 	require.Nil(t, err)
 	expectRequest := types.NewRequest(1, calldata,
 		[]sdk.ValAddress{validatorAddress2, validatorAddress1}, 2,
-		2, 1581589790, "clientID",
+		2, 1581589790, "clientID", nil,
 	)
 	require.Equal(t, expectRequest, actualRequest)
 
@@ -306,9 +306,9 @@ func TestRequestIBCSuccess(t *testing.T) {
 	require.Equal(t, int64(1), keeper.GetRequestCount(ctx))
 	actualRequest, err := keeper.GetRequest(ctx, 1)
 	require.Nil(t, err)
-	expectRequest := types.NewRequestWithRequestIBC(1, calldata,
+	expectRequest := types.NewRequest(1, calldata,
 		[]sdk.ValAddress{validatorAddress2, validatorAddress1}, 2,
-		2, 1581589790, "clientID", sourcePort, sourceChannel,
+		2, 1581589790, "clientID", &types.RequestIBC{sourcePort, sourceChannel},
 	)
 	require.Equal(t, expectRequest, actualRequest)
 
@@ -563,7 +563,7 @@ func TestReportSuccess(t *testing.T) {
 
 	request := types.NewRequest(1, calldata,
 		[]sdk.ValAddress{validatorAddress2, validatorAddress1}, 2,
-		2, 1581589790, "clientID",
+		2, 1581589790, "clientID", nil,
 	)
 	keeper.SetRequest(ctx, 1, request)
 	keeper.SetRawRequest(ctx, 1, types.NewRawRequest(42, 1, []byte("calldata1")))
@@ -620,7 +620,7 @@ func TestReportFailed(t *testing.T) {
 
 	request := types.NewRequest(1, calldata,
 		[]sdk.ValAddress{validatorAddress2, validatorAddress1}, 2,
-		2, 1581589790, "clientID",
+		2, 1581589790, "clientID", nil,
 	)
 	keeper.SetRequest(ctx, 1, request)
 	keeper.SetRawRequest(ctx, 1, types.NewRawRequest(42, 1, []byte("calldata1")))
@@ -727,7 +727,7 @@ func TestAddAndRemoveOracleAddress(t *testing.T) {
 
 	request := types.NewRequest(1, calldata,
 		[]sdk.ValAddress{validatorAddress2, validatorAddress1}, 2,
-		2, 1581589790, "clientID",
+		2, 1581589790, "clientID", nil,
 	)
 	keeper.SetRequest(ctx, 1, request)
 	keeper.SetRawRequest(ctx, 1, types.NewRawRequest(42, 1, []byte("calldata1")))

--- a/chain/x/oracle/keeper/keeper.go
+++ b/chain/x/oracle/keeper/keeper.go
@@ -1,10 +1,8 @@
 package keeper
 
 import (
-	"time"
+	"fmt"
 
-	"github.com/bandprotocol/bandchain/chain/owasm"
-	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
@@ -13,15 +11,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/params"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
-)
+	"github.com/tendermint/tendermint/libs/log"
 
-const (
-	// DefaultPacketTimeoutHeight is the default packet timeout height relative
-	// to the current block height. The timeout is disabled when set to 0.
-	DefaultPacketTimeoutHeight = 0 // NOTE: in blocks
-
-	// DefaultPacketTimeoutTimestampDuration is the default packet timeout duration
-	DefaultPacketTimeoutTimestampDuration = uint64(600 * time.Second) // NOTE: in nanoseconds
+	"github.com/bandprotocol/bandchain/chain/owasm"
+	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
 )
 
 type Keeper struct {
@@ -56,6 +49,11 @@ func NewKeeper(
 		ScopedKeeper:  scopedKeeper,
 		PortKeeper:    portKeeper,
 	}
+}
+
+// Logger returns a module-specific logger.
+func (k Keeper) Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
 // ParamKeyTable returns the parameter key table for oracle module.

--- a/chain/x/oracle/keeper/relayer.go
+++ b/chain/x/oracle/keeper/relayer.go
@@ -1,0 +1,51 @@
+package keeper
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	channel "github.com/cosmos/cosmos-sdk/x/ibc/04-channel"
+	ibctypes "github.com/cosmos/cosmos-sdk/x/ibc/types"
+)
+
+const (
+	// DefaultPacketTimeoutHeight is set to 0 to disable block height based timeout.
+	DefaultPacketTimeoutHeight = 0 // NOTE: in blocks
+
+	// DefaultPacketTimeoutTimestampDuration is set to 10 minutes from BandChain's block time.
+	DefaultPacketTimeoutTimestampDuration = uint64(600 * time.Second) // NOTE: in nanoseconds
+)
+
+// SendOracleResponse sends the given oracle response packet through the given IBC channel/port.
+func (k Keeper) SendOracleResponse(ctx sdk.Context, portID, channelID string, res types.OracleResponsePacketData) {
+	logger := k.Logger(ctx)
+	ch, ok := k.ChannelKeeper.GetChannel(ctx, portID, channelID)
+	if !ok {
+		logger.Error(fmt.Sprintf("failed to get channel with id: %s, port: %s", channelID, portID))
+		return
+	}
+
+	seq, ok := k.ChannelKeeper.GetNextSequenceSend(ctx, portID, channelID)
+	if !ok {
+		logger.Error(fmt.Sprintf("failed to get next sequence for channel id: %s, port: %s", channelID, portID))
+		return
+	}
+
+	chCap, ok := k.ScopedKeeper.GetCapability(ctx, ibctypes.ChannelCapabilityPath(portID, channelID))
+	if !ok {
+		logger.Error(fmt.Sprintf("failed to get channel capability for id: %s, port: %s", channelID, portID))
+		return
+	}
+
+	packet := channel.NewPacket(
+		res.GetBytes(), seq, portID, channelID, ch.Counterparty.PortID, ch.Counterparty.ChannelID,
+		DefaultPacketTimeoutHeight, // TimeoutHeight
+		uint64(ctx.BlockTime().UnixNano())+DefaultPacketTimeoutTimestampDuration, // TimeoutTimestamp
+	)
+	err := k.ChannelKeeper.SendPacket(ctx, chCap, packet)
+	if err != nil {
+		logger.Error(fmt.Sprintf("failed to send IBC packet for channel id: %s, port: %s, err: %s", channelID, portID, err.Error()))
+	}
+}

--- a/chain/x/oracle/keeper/request.go
+++ b/chain/x/oracle/keeper/request.go
@@ -76,11 +76,13 @@ func (k Keeper) AddRequest(ctx sdk.Context, req types.Request) (types.RequestID,
 	return id, nil
 }
 
+// ResolveRequest updates the request with resolve status and result, and saves the commitment
+// pair of oracle request/response packets to the store. Returns back the response packet.
 func (k Keeper) ResolveRequest(
-	ctx sdk.Context, id types.RequestID, resolveStatus types.ResolveStatus, result []byte,
+	ctx sdk.Context, id types.RID, status types.ResolveStatus, result []byte,
 ) types.OracleResponsePacketData {
-	request := k.MustGetRequest(ctx, id)
 
+	request := k.MustGetRequest(ctx, id)
 	req := types.NewOracleRequestPacketData(
 		request.ClientID, request.OracleScriptID,
 		hex.EncodeToString(request.Calldata), request.SufficientValidatorCount,
@@ -91,12 +93,12 @@ func (k Keeper) ResolveRequest(
 		ctx.BlockTime().Unix(), types.Success, hex.EncodeToString(result),
 	)
 
-	if resolveStatus != types.Success {
+	if status != types.Success {
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(
 				types.EventTypeRequestExecute,
 				sdk.NewAttribute(types.AttributeKeyRequestID, fmt.Sprintf("%d", id)),
-				sdk.NewAttribute(types.AttributeKeyResolveStatus, fmt.Sprintf("%d", resolveStatus)),
+				sdk.NewAttribute(types.AttributeKeyResolveStatus, fmt.Sprintf("%d", status)),
 			))
 		return res
 	}

--- a/chain/x/oracle/keeper/request_test.go
+++ b/chain/x/oracle/keeper/request_test.go
@@ -13,14 +13,14 @@ func TestHasRequest(t *testing.T) {
 	// We should not have a request ID 42 without setting it.
 	require.False(t, k.HasRequest(ctx, 42))
 	// After we set it, we should be able to find it.
-	k.SetRequest(ctx, 42, types.NewRequest(1, BasicCalldata, nil, 1, 1, 1, ""))
+	k.SetRequest(ctx, 42, types.NewRequest(1, BasicCalldata, nil, 1, 1, 1, "", nil))
 	require.True(t, k.HasRequest(ctx, 42))
 }
 
 func TestDeleteRequest(t *testing.T) {
 	_, ctx, k := createTestInput()
 	// After we set it, we should be able to find it.
-	k.SetRequest(ctx, 42, types.NewRequest(1, BasicCalldata, nil, 1, 1, 1, ""))
+	k.SetRequest(ctx, 42, types.NewRequest(1, BasicCalldata, nil, 1, 1, 1, "", nil))
 	require.True(t, k.HasRequest(ctx, 42))
 	// After we delete it, we should not find it anymore.
 	k.DeleteRequest(ctx, 42)
@@ -37,8 +37,8 @@ func TestSetterGetterRequest(t *testing.T) {
 	require.Error(t, err)
 	require.Panics(t, func() { _ = k.MustGetRequest(ctx, 42) })
 	// Creates some basic requests.
-	req1 := types.NewRequest(1, BasicCalldata, nil, 1, 1, 1, "")
-	req2 := types.NewRequest(2, BasicCalldata, nil, 1, 1, 1, "")
+	req1 := types.NewRequest(1, BasicCalldata, nil, 1, 1, 1, "", nil)
+	req2 := types.NewRequest(2, BasicCalldata, nil, 1, 1, 1, "", nil)
 	// Sets id 42 with request 1 and id 42 with request 2.
 	k.SetRequest(ctx, 42, req1)
 	k.SetRequest(ctx, 43, req2)
@@ -79,11 +79,11 @@ func TestAddDataSourceBasic(t *testing.T) {
 		Owner.Address, BasicName, BasicDesc, BasicCode, BasicSchema, BasicSourceCodeURL,
 	))
 	// Adding the first request should return ID 1.
-	id, err := k.AddRequest(ctx, types.NewRequest(42, BasicCalldata, nil, 1, 1, 1, ""))
+	id, err := k.AddRequest(ctx, types.NewRequest(42, BasicCalldata, nil, 1, 1, 1, "", nil))
 	require.Nil(t, err)
 	require.Equal(t, id, types.RID(1))
 	// Adding another request should return ID 2.
-	id, err = k.AddRequest(ctx, types.NewRequest(42, BasicCalldata, nil, 1, 1, 1, ""))
+	id, err = k.AddRequest(ctx, types.NewRequest(42, BasicCalldata, nil, 1, 1, 1, "", nil))
 	require.Nil(t, err)
 	require.Equal(t, id, types.RID(2))
 }
@@ -92,7 +92,7 @@ func TestAddRequestNoOracleScript(t *testing.T) {
 	_, ctx, k := createTestInput()
 	// Adding a new request that refers a non-existent oracle script should fail.
 	require.False(t, k.HasOracleScript(ctx, 42))
-	_, err := k.AddRequest(ctx, types.NewRequest(42, BasicCalldata, nil, 1, 1, 1, ""))
+	_, err := k.AddRequest(ctx, types.NewRequest(42, BasicCalldata, nil, 1, 1, 1, "", nil))
 	require.Error(t, err)
 }
 
@@ -106,13 +106,13 @@ func TestAddRequestTooBigCalldata(t *testing.T) {
 	// We set max calldata sie to 41, so adding a request with calldata size 42 should fail.
 	k.SetParam(ctx, types.KeyMaxCalldataSize, 41)
 	_, err := k.AddRequest(ctx, types.NewRequest(42,
-		[]byte("________THIS_STRING_HAS_SIZE_OF_42________"), nil, 1, 1, 1, ""),
+		[]byte("________THIS_STRING_HAS_SIZE_OF_42________"), nil, 1, 1, 1, "", nil),
 	)
 	require.Error(t, err)
 	// We now change max calldata size to 42, so it should be fine.
 	k.SetParam(ctx, types.KeyMaxCalldataSize, 42)
 	_, err = k.AddRequest(ctx, types.NewRequest(42,
-		[]byte("________THIS_STRING_HAS_SIZE_OF_42________"), nil, 1, 1, 1, ""),
+		[]byte("________THIS_STRING_HAS_SIZE_OF_42________"), nil, 1, 1, 1, "", nil),
 	)
 	require.Nil(t, err)
 }

--- a/chain/x/oracle/keeper/test_common.go
+++ b/chain/x/oracle/keeper/test_common.go
@@ -228,6 +228,7 @@ func newDefaultRequest() types.Request {
 		0,
 		1581503227,
 		"clientID",
+		nil,
 	)
 }
 

--- a/chain/x/oracle/types/request.go
+++ b/chain/x/oracle/types/request.go
@@ -22,8 +22,7 @@ type Request struct {
 	RequestHeight            int64            `json:"request_height"`
 	RequestTime              int64            `json:"request_time"`
 	ClientID                 string           `json:"client_id"`
-
-	RequestIBC *RequestIBC `json:"request_ibc"`
+	IBC                      *RequestIBC      `json:"ibc"`
 }
 
 type RequestIBC struct {
@@ -40,6 +39,7 @@ func NewRequest(
 	requestHeight int64,
 	requestTime int64,
 	clientID string,
+	ibc *RequestIBC,
 ) Request {
 	return Request{
 		OracleScriptID:           oracleScriptID,
@@ -49,33 +49,7 @@ func NewRequest(
 		RequestHeight:            requestHeight,
 		RequestTime:              requestTime,
 		ClientID:                 clientID,
-		RequestIBC:               nil,
-	}
-}
-
-func NewRequestWithRequestIBC(
-	oracleScriptID OracleScriptID,
-	calldata []byte,
-	requestedValidators []sdk.ValAddress,
-	sufficientValidatorCount int64,
-	requestHeight int64,
-	requestTime int64,
-	clientID string,
-	sourcePort string,
-	sourceChannel string,
-) Request {
-	return Request{
-		OracleScriptID:           oracleScriptID,
-		Calldata:                 calldata,
-		RequestedValidators:      requestedValidators,
-		SufficientValidatorCount: sufficientValidatorCount,
-		RequestHeight:            requestHeight,
-		RequestTime:              requestTime,
-		ClientID:                 clientID,
-		RequestIBC: &RequestIBC{
-			SourcePort:    sourcePort,
-			SourceChannel: sourceChannel,
-		},
+		IBC:                      ibc,
 	}
 }
 


### PR DESCRIPTION
- Make SendOracleResponse not depend on request keeper at all. It just sends packets.
- Make sure expired requests get sent back to requester.
- Use error as result for failed requests.
- Merge NewRequest function into one.