### PR TITLE
cacher: keep all vote info for stats on scan

### DIFF
--- a/chain/app/db_app.go
+++ b/chain/app/db_app.go
@@ -243,11 +243,6 @@ func (app *dbBandApp) BeginBlock(req abci.RequestBeginBlock) (res abci.ResponseB
 		)
 	}
 
-	err = app.dbBand.ClearOldVotes(req.Header.GetHeight() - 1)
-	if err != nil {
-		panic(err)
-	}
-
 	app.dbBand.AddBlock(
 		req.Header.GetHeight(),
 		app.DeliverContext.BlockTime(),

--- a/chain/cmd/bandd/main.go
+++ b/chain/cmd/bandd/main.go
@@ -28,9 +28,8 @@ import (
 )
 
 const (
-	flagInvCheckPeriod         = "inv-check-period"
-	flagWithDB                 = "with-db"
-	flagUptimeLookBackDuration = "uptime-look-back"
+	flagInvCheckPeriod = "inv-check-period"
+	flagWithDB         = "with-db"
 )
 
 var invCheckPeriod uint
@@ -78,9 +77,6 @@ func main() {
 	rootCmd.PersistentFlags().String(
 		flagWithDB, "", "[Experimental] Flush blockchain state to SQL database",
 	)
-	rootCmd.PersistentFlags().Int64(
-		flagUptimeLookBackDuration, 1000, "[Experimental] Historical node uptime lookback duration",
-	)
 
 	err := executor.Execute()
 	if err != nil {
@@ -105,10 +101,7 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 		if len(dbSplit) != 2 {
 			panic("Invalid DB string format")
 		}
-		metadata := map[string]string{
-			banddb.KeyUptimeLookBackDuration: viper.GetString(flagUptimeLookBackDuration),
-		}
-		bandDB, err := banddb.NewDB(dbSplit[0], dbSplit[1], metadata)
+		bandDB, err := banddb.NewDB(dbSplit[0], dbSplit[1])
 		if err != nil {
 			panic(err)
 		}

--- a/chain/db/db.go
+++ b/chain/db/db.go
@@ -38,7 +38,7 @@ type BandDB struct {
 	IBCKeeper     *ibc.Keeper
 }
 
-func NewDB(dialect, path string, metadata map[string]string) (*BandDB, error) {
+func NewDB(dialect, path string) (*BandDB, error) {
 	db, err := gorm.Open(dialect, path)
 	if err != nil {
 		return nil, err
@@ -234,15 +234,6 @@ func NewDB(dialect, path string, metadata map[string]string) (*BandDB, error) {
 		"RESTRICT",
 		"RESTRICT",
 	)
-
-	for key, value := range metadata {
-		err := db.Where(Metadata{Key: key}).
-			Assign(Metadata{Value: value}).
-			FirstOrCreate(&Metadata{}).Error
-		if err != nil {
-			panic(err)
-		}
-	}
 
 	return &BandDB{db: db}, nil
 }

--- a/chain/db/metadata.go
+++ b/chain/db/metadata.go
@@ -9,11 +9,10 @@ import (
 )
 
 const (
-	KeyChainID                = "chain_id"
-	KeyLastProcessedHeight    = "last_processed_height"
-	KeyUptimeLookBackDuration = "uptime_look_back_duration"
-	KeyInflationRate          = "inflation_rate"
-	KeyTotalSupply            = "total_supply"
+	KeyChainID             = "chain_id"
+	KeyLastProcessedHeight = "last_processed_height"
+	KeyInflationRate       = "inflation_rate"
+	KeyTotalSupply         = "total_supply"
 )
 
 func (b *BandDB) GetMetadataValue(key string) (string, error) {
@@ -68,14 +67,6 @@ func (b *BandDB) SetLastProcessedHeight(height int64) error {
 
 func (b *BandDB) GetLastProcessedHeight() (int64, error) {
 	return b.GetMetadataValueInt64(KeyLastProcessedHeight)
-}
-
-func (b *BandDB) SetUptimeLookBackDuration(duration int64) error {
-	return b.SetMetadataValueInt64(KeyUptimeLookBackDuration, duration)
-}
-
-func (b *BandDB) GetUptimeLookBackDuration() (int64, error) {
-	return b.GetMetadataValueInt64(KeyUptimeLookBackDuration)
 }
 
 func (b *BandDB) SetInflationRate(inflationRate string) error {

--- a/chain/db/table.go
+++ b/chain/db/table.go
@@ -40,9 +40,6 @@ type Validator struct {
 	OperatorAddress     string  `gorm:"primary_key"`
 	ConsensusAddress    string  `gorm:"unique;not null"`
 	ConsensusPubkey     string  `gorm:"not null"`
-	ElectedCount        uint    `gorm:"not null"` // TODO: Update to pointer
-	VotedCount          uint    `gorm:"not null"` // TODO: Update to pointer
-	MissedCount         uint    `gorm:"not null"` // TODO: Update to pointer
 	Moniker             string  `gorm:"not null"` // TODO: Update to pointer
 	Identity            string  `gorm:"not null"` // TODO: Update to pointer
 	Website             string  `gorm:"not null"` // TODO: Update to pointer


### PR DESCRIPTION
This allows scan to show more comprehensive uptime stat in a more flexible way. @evilpeach Scan will need to update the way to get uptime %.