### PR TITLE
chain: Use dash for bandcli report-info

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,7 @@
 
 ### Chain
 
+- (bug) [\#2046](https://github.com/bandprotocol/bandchain/pull/2043) Use dash for bandcli report-info.
 - (impv) [\#2043](https://github.com/bandprotocol/bandchain/pull/2043) Add full raw requests information in request struct.
 - (chore) [\#2040](https://github.com/bandprotocol/bandchain/pull/2040) Set HomeFlag to /tmp for SimApp.
 - (patch) [\#2037](https://github.com/bandprotocol/bandchain/pull/2037) Patch Multistore proof to new structure tree of 0.38.

--- a/chain/x/oracle/client/cli/query.go
+++ b/chain/x/oracle/client/cli/query.go
@@ -166,7 +166,7 @@ func GetQueryCmdReporters(route string, cdc *codec.Codec) *cobra.Command {
 // GetQueryCmdReportInfo implements the query report info command.
 func GetQueryCmdReportInfo(route string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:  "report_info [validator]",
+		Use:  "report-info [validator]",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)


### PR DESCRIPTION
Make it consistent with other CLI commands.