### PR TITLE
chain: Fix request search ordering in 0.38

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,7 @@
 
 ### Chain
 
+- (bug) [\#2047](https://github.com/bandprotocol/bandchain/pull/2047) Fix request search ordering in 0.38.
 - (impv) [\#2043](https://github.com/bandprotocol/bandchain/pull/2043) Add full raw requests information in request struct.
 - (chore) [\#2040](https://github.com/bandprotocol/bandchain/pull/2040) Set HomeFlag to /tmp for SimApp.
 - (patch) [\#2037](https://github.com/bandprotocol/bandchain/pull/2037) Patch Multistore proof to new structure tree of 0.38.


### PR DESCRIPTION
Current SDK version 0.38 does not directly expose the ordering parameter in `cliCtx`, even though Tendermint already supports it. This PR makes sure request-search perform correctly by calling directly into Tendermint function.