### PR TITLE
chain: Set count state on genesis.go and remove default values from getters

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,7 @@
 
 ### Chain
 
+- (impv) [\2080](https://github.com/bandprotocol/bandchain/pull/2080) Set count state on genesis.go and remove default values from getters.
 - (feat) [\#2022](https://github.com/bandprotocol/bandchain/pull/2022) Initial implementation of BandChain emitter/flusher.
 - (chore) [\#2060](https://github.com/bandprotocol/bandchain/pull/2060) Remove unused /bandchain/file endpoints and custom swagger from bandcli REST.
 

--- a/chain/x/oracle/genesis.go
+++ b/chain/x/oracle/genesis.go
@@ -33,10 +33,10 @@ func InitGenesis(ctx sdk.Context, k Keeper, data GenesisState) []abci.ValidatorU
 	k.SetParam(ctx, types.KeyMaxConsecutiveMisses, data.Params.MaxConsecutiveMisses)
 	k.SetParam(ctx, types.KeyBaseRequestGas, data.Params.BaseRequestGas)
 	k.SetParam(ctx, types.KeyPerValidatorRequestGas, data.Params.PerValidatorRequestGas)
-	k.SetRequestCount(ctx, 0)
-	k.SetRequestLastExpired(ctx, 0)
 	k.SetDataSourceCount(ctx, 0)
 	k.SetOracleScriptCount(ctx, 0)
+	k.SetRequestCount(ctx, 0)
+	k.SetRequestLastExpired(ctx, 0)
 	for _, dataSource := range data.DataSources {
 		_ = k.AddDataSource(ctx, dataSource)
 	}

--- a/chain/x/oracle/genesis.go
+++ b/chain/x/oracle/genesis.go
@@ -33,6 +33,10 @@ func InitGenesis(ctx sdk.Context, k Keeper, data GenesisState) []abci.ValidatorU
 	k.SetParam(ctx, types.KeyMaxConsecutiveMisses, data.Params.MaxConsecutiveMisses)
 	k.SetParam(ctx, types.KeyBaseRequestGas, data.Params.BaseRequestGas)
 	k.SetParam(ctx, types.KeyPerValidatorRequestGas, data.Params.PerValidatorRequestGas)
+	k.SetRequestCount(ctx, 0)
+	k.SetRequestLastExpired(ctx, 0)
+	k.SetDataSourceCount(ctx, 0)
+	k.SetOracleScriptCount(ctx, 0)
 	for _, dataSource := range data.DataSources {
 		_ = k.AddDataSource(ctx, dataSource)
 	}

--- a/chain/x/oracle/keeper/keeper.go
+++ b/chain/x/oracle/keeper/keeper.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -75,32 +74,25 @@ func (k Keeper) SetRequestCount(ctx sdk.Context, count int64) {
 func (k Keeper) GetRequestCount(ctx sdk.Context) int64 {
 	var requestNumber int64
 	bz := ctx.KVStore(k.storeKey).Get(types.RequestCountStoreKey)
-	if bz == nil {
-		return 0
-	}
 	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &requestNumber)
 	return requestNumber
 }
 
-// SetRequestCount sets the ID of the last expired request.
+// SetRequestLastExpired sets the ID of the last expired request.
 func (k Keeper) SetRequestLastExpired(ctx sdk.Context, id int64) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.RequestLastExpiredStoreKey, k.cdc.MustMarshalBinaryLengthPrefixed(id))
 }
 
-// SetRequestLastExpired returns the ID of the last expired request.
+// GetRequestLastExpired returns the ID of the last expired request.
 func (k Keeper) GetRequestLastExpired(ctx sdk.Context) int64 {
 	var requestNumber int64
 	bz := ctx.KVStore(k.storeKey).Get(types.RequestLastExpiredStoreKey)
-	if bz == nil {
-		return 0
-	}
 	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &requestNumber)
 	return requestNumber
 }
 
 // GetNextRequestID increments and returns the current number of requests.
-// If the global request count is not set, it initializes it with value 0.
 func (k Keeper) GetNextRequestID(ctx sdk.Context) types.RequestID {
 	requestNumber := k.GetRequestCount(ctx)
 	bz := k.cdc.MustMarshalBinaryLengthPrefixed(requestNumber + 1)
@@ -108,53 +100,46 @@ func (k Keeper) GetNextRequestID(ctx sdk.Context) types.RequestID {
 	return types.RequestID(requestNumber + 1)
 }
 
+// SetDataSourceCount sets the number of data source count to the given value.
+func (k Keeper) SetDataSourceCount(ctx sdk.Context, count int64) {
+	bz := k.cdc.MustMarshalBinaryLengthPrefixed(count)
+	ctx.KVStore(k.storeKey).Set(types.DataSourceCountStoreKey, bz)
+}
+
 // GetDataSourceCount returns the current number of all data sources ever exist.
 func (k Keeper) GetDataSourceCount(ctx sdk.Context) int64 {
 	var dataSourceCount int64
 	bz := ctx.KVStore(k.storeKey).Get(types.DataSourceCountStoreKey)
-	if bz == nil {
-		return 0
-	}
 	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &dataSourceCount)
 	return dataSourceCount
 }
 
 // GetNextDataSourceID increments and returns the current number of data source.
-// If the global data source count is not set, it initializes the value and returns 1.
 func (k Keeper) GetNextDataSourceID(ctx sdk.Context) types.DataSourceID {
 	dataSourceCount := k.GetDataSourceCount(ctx)
-	bz := k.cdc.MustMarshalBinaryLengthPrefixed(dataSourceCount + 1)
-	ctx.KVStore(k.storeKey).Set(types.DataSourceCountStoreKey, bz)
+	k.SetDataSourceCount(ctx, dataSourceCount+1)
 	return types.DataSourceID(dataSourceCount + 1)
+}
+
+// SetOracleScriptCount sets the number of oracle script count to the given value.
+func (k Keeper) SetOracleScriptCount(ctx sdk.Context, count int64) {
+	bz := k.cdc.MustMarshalBinaryLengthPrefixed(count)
+	ctx.KVStore(k.storeKey).Set(types.OracleScriptCountStoreKey, bz)
 }
 
 // GetOracleScriptCount returns the current number of all oracle scripts ever exist.
 func (k Keeper) GetOracleScriptCount(ctx sdk.Context) int64 {
 	var oracleScriptCount int64
 	bz := ctx.KVStore(k.storeKey).Get(types.OracleScriptCountStoreKey)
-	if bz == nil {
-		return 0
-	}
 	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &oracleScriptCount)
 	return oracleScriptCount
 }
 
 // GetNextOracleScriptID increments and returns the current number of oracle script.
-// If the global oracle script count is not set, it initializes the value and returns 1.
 func (k Keeper) GetNextOracleScriptID(ctx sdk.Context) types.OracleScriptID {
 	oracleScriptCount := k.GetOracleScriptCount(ctx)
-	bz := k.cdc.MustMarshalBinaryLengthPrefixed(oracleScriptCount + 1)
-	ctx.KVStore(k.storeKey).Set(types.OracleScriptCountStoreKey, bz)
+	k.SetOracleScriptCount(ctx, oracleScriptCount+1)
 	return types.OracleScriptID(oracleScriptCount + 1)
-}
-
-// AddFile saves the given data to a file in HOME/files directory using sha256 sum as filename.
-// Returns do-not-modify symbol is the given input file is do-not-modify.
-func (k Keeper) AddFile(file []byte) string {
-	if bytes.Equal(file, types.DoNotModifyBytes) {
-		return types.DoNotModify
-	}
-	return k.fileCache.AddFile(file)
 }
 
 // GetFile loads the file from the file storage. Panics if the file does not exist.


### PR DESCRIPTION
This PR makes sure all values with prefix GlobalStoreKeyPrefix are set during genesis. This allows simpler implementation of getters so they don't need to have default values. It also simplifies how we reason about chain state.