### PR TITLE
oracled: Set max capacity of event subscription channel

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,7 +10,7 @@
 
 ### Chain
 
-- (bug) [\#2110](https://github.com/bandprotocol/bandchain/pull/2074) Set`bandoracled` max capacity of event subscription channel.
+- (bug) [\#2110](https://github.com/bandprotocol/bandchain/pull/2074) Set `bandoracled` max capacity of event subscription channel.
 - (impv) [\#2074](https://github.com/bandprotocol/bandchain/pull/2074) Use rolling block hash as seed for validator sampling.
 - (impv) [\#2104](https://github.com/bandprotocol/bandchain/pull/2104) Update default gas/size consensus params and clean up cmd code.
 - (chore) [\#2084](https://github.com/bandprotocol/bandchain/pull/2084) Rename ValidatorReportInto to ReportInfo.

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,7 @@
 
 ### Chain
 
+- (bug) [\#2110](https://github.com/bandprotocol/bandchain/pull/2074) Set`bandoracled` max capacity of event subscription channel.
 - (impv) [\#2074](https://github.com/bandprotocol/bandchain/pull/2074) Use rolling block hash as seed for validator sampling.
 - (impv) [\#2104](https://github.com/bandprotocol/bandchain/pull/2104) Update default gas/size consensus params and clean up cmd code.
 - (chore) [\#2084](https://github.com/bandprotocol/bandchain/pull/2084) Rename ValidatorReportInto to ReportInfo.

--- a/chain/cmd/bandoracled2/run.go
+++ b/chain/cmd/bandoracled2/run.go
@@ -21,6 +21,8 @@ import (
 const (
 	// TODO: We can subscribe only for txs that contain request messages
 	TxQuery = "tm.event = 'Tx'"
+	// EventChannelCapacity is a buffer size of channel between node and this program
+	EventChannelCapacity = 2000
 )
 
 func runImpl(c *Context, l *Logger) error {
@@ -34,7 +36,7 @@ func runImpl(c *Context, l *Logger) error {
 	defer cxl()
 
 	l.Info(":ear: Subscribing to events with query: %s...", TxQuery)
-	eventChan, err := c.client.Subscribe(ctx, "", TxQuery)
+	eventChan, err := c.client.Subscribe(ctx, "", TxQuery, EventChannelCapacity)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fixed: #2099
Fixed: #1409 

## Implementation details

After investigate why `bandoracled` miss report, we found that the program cannot catch all requests via subscription channel. We try to increase the size of the channel that makes node can write all tx to channel correctly. Now we test `bandoracled` listen 20 concurrently requests and no missing report.

Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests (Already test on devnet)
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
