### PR TITLE
chain: Update default genesis parameters

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,7 @@
 
 ### Chain
 
+- (impv) [\#2161](https://github.com/bandprotocol/bandchain/pull/2161) Update default genesis parameters for oracle and distr.
 - (impv) [\#2151](https://github.com/bandprotocol/bandchain/pull/2151) Fix `exec_env` code more consistent.
 - (impv) [\#2144](https://github.com/bandprotocol/bandchain/pull/2144) Add validator votes table.
 - (impv) [\#2148](https://github.com/bandprotocol/bandchain/pull/2148) Add more unit tests and fix nil retdata and nil calldata.

--- a/chain/app/genesis.go
+++ b/chain/app/genesis.go
@@ -31,6 +31,7 @@ func NewDefaultGenesisState() GenesisState {
 	// Get default genesis states of the modules we are to override.
 	authGenesis := auth.DefaultGenesisState()
 	stakingGenesis := staking.DefaultGenesisState()
+	distrGenesis := distr.DefaultGenesisState()
 	mintGenesis := mint.DefaultGenesisState()
 	govGenesis := gov.DefaultGenesisState()
 	crisisGenesis := crisis.DefaultGenesisState()
@@ -39,7 +40,9 @@ func NewDefaultGenesisState() GenesisState {
 	authGenesis.Params.TxSizeCostPerByte = 5
 	stakingGenesis.Params.BondDenom = denom
 	stakingGenesis.Params.HistoricalEntries = 1000
-	mintGenesis.Params.BlocksPerYear = 10519200 // target 3-second block time
+	distrGenesis.Params.BaseProposerReward = sdk.NewDecWithPrec(2, 2)  // 2%
+	distrGenesis.Params.BonusProposerReward = sdk.NewDecWithPrec(8, 2) // 8%
+	mintGenesis.Params.BlocksPerYear = 10519200                        // target 3-second block time
 	mintGenesis.Params.MintDenom = denom
 	govGenesis.DepositParams.MinDeposit = sdk.NewCoins(sdk.NewCoin(denom, sdk.TokensFromConsensusPower(1000)))
 	crisisGenesis.ConstantFee = sdk.NewCoin(denom, sdk.TokensFromConsensusPower(10000))
@@ -55,7 +58,7 @@ func NewDefaultGenesisState() GenesisState {
 		supply.ModuleName:   supply.AppModuleBasic{}.DefaultGenesis(),
 		staking.ModuleName:  cdc.MustMarshalJSON(stakingGenesis),
 		mint.ModuleName:     cdc.MustMarshalJSON(mintGenesis),
-		distr.ModuleName:    distr.AppModuleBasic{}.DefaultGenesis(),
+		distr.ModuleName:    cdc.MustMarshalJSON(distrGenesis),
 		gov.ModuleName:      cdc.MustMarshalJSON(govGenesis),
 		crisis.ModuleName:   cdc.MustMarshalJSON(crisisGenesis),
 		slashing.ModuleName: cdc.MustMarshalJSON(slashingGenesis),

--- a/chain/app/genesis.go
+++ b/chain/app/genesis.go
@@ -40,9 +40,9 @@ func NewDefaultGenesisState() GenesisState {
 	authGenesis.Params.TxSizeCostPerByte = 5
 	stakingGenesis.Params.BondDenom = denom
 	stakingGenesis.Params.HistoricalEntries = 1000
-	distrGenesis.Params.BaseProposerReward = sdk.NewDecWithPrec(2, 2)  // 2%
-	distrGenesis.Params.BonusProposerReward = sdk.NewDecWithPrec(8, 2) // 8%
-	mintGenesis.Params.BlocksPerYear = 10519200                        // target 3-second block time
+	distrGenesis.Params.BaseProposerReward = sdk.NewDecWithPrec(3, 2)   // 3%
+	distrGenesis.Params.BonusProposerReward = sdk.NewDecWithPrec(12, 2) // 12%
+	mintGenesis.Params.BlocksPerYear = 10519200                         // target 3-second block time
 	mintGenesis.Params.MintDenom = denom
 	govGenesis.DepositParams.MinDeposit = sdk.NewCoins(sdk.NewCoin(denom, sdk.TokensFromConsensusPower(1000)))
 	crisisGenesis.ConstantFee = sdk.NewCoin(denom, sdk.TokensFromConsensusPower(10000))

--- a/chain/x/oracle/abci_test.go
+++ b/chain/x/oracle/abci_test.go
@@ -139,14 +139,14 @@ func TestAllocateTokensWithDistrAllocateTokens(t *testing.T) {
 	//     34.3uband go to validator1 (active)
 	//   15uband = 30% go to distr pool
 	//     0.3uband (2%) go to community pool
-	//     0.75uband (5%) go to validator2 (proposer)
-	//     13.95uband split among voters
-	//        9.765uband (70%) go to validator1
-	//        4.185uband (30%) go to validator2
+	//     1.5uband (10%) go to validator2 (proposer)
+	//     13.2uband split among voters
+	//        9.24uband (70%) go to validator1
+	//        3.96uband (30%) go to validator2
 	// In summary
 	//   Community pool: 0.7 + 0.3 = 1
-	//   Validator1: 34.3 + 9.765 = 44.065
-	//   Validator2: 0.75 + 4.185 = 4.935
+	//   Validator1: 34.3 + 9.24 = 43.54
+	//   Validator2: 1.5 + 3.96 = 5.46
 	k.Activate(ctx, testapp.Validator1.ValAddress)
 	app.BeginBlocker(ctx, abci.RequestBeginBlock{
 		Hash:           fromHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
@@ -155,6 +155,6 @@ func TestAllocateTokensWithDistrAllocateTokens(t *testing.T) {
 	require.Equal(t, sdk.Coins(nil), app.SupplyKeeper.GetModuleAccount(ctx, auth.FeeCollectorName).GetCoins())
 	require.Equal(t, sdk.NewCoins(sdk.NewInt64Coin("uband", 50)), app.SupplyKeeper.GetModuleAccount(ctx, distribution.ModuleName).GetCoins())
 	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDec(1)}}, app.DistrKeeper.GetFeePool(ctx).CommunityPool)
-	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(44065, 3)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator1.ValAddress))
-	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(4935, 3)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator2.ValAddress))
+	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(4354, 2)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator1.ValAddress))
+	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(546, 2)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator2.ValAddress))
 }

--- a/chain/x/oracle/abci_test.go
+++ b/chain/x/oracle/abci_test.go
@@ -139,14 +139,14 @@ func TestAllocateTokensWithDistrAllocateTokens(t *testing.T) {
 	//     34.3uband go to validator1 (active)
 	//   15uband = 30% go to distr pool
 	//     0.3uband (2%) go to community pool
-	//     1.5uband (10%) go to validator2 (proposer)
-	//     13.2uband split among voters
-	//        9.24uband (70%) go to validator1
-	//        3.96uband (30%) go to validator2
+	//     2.25uband (15%) go to validator2 (proposer)
+	//     12.45uband split among voters
+	//        8.715uband (70%) go to validator1
+	//        3.735uband (30%) go to validator2
 	// In summary
 	//   Community pool: 0.7 + 0.3 = 1
-	//   Validator1: 34.3 + 9.24 = 43.54
-	//   Validator2: 1.5 + 3.96 = 5.46
+	//   Validator1: 34.3 + 8.715 = 43.015
+	//   Validator2: 2.25 + 3.735 = 5.985
 	k.Activate(ctx, testapp.Validator1.ValAddress)
 	app.BeginBlocker(ctx, abci.RequestBeginBlock{
 		Hash:           fromHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
@@ -155,6 +155,6 @@ func TestAllocateTokensWithDistrAllocateTokens(t *testing.T) {
 	require.Equal(t, sdk.Coins(nil), app.SupplyKeeper.GetModuleAccount(ctx, auth.FeeCollectorName).GetCoins())
 	require.Equal(t, sdk.NewCoins(sdk.NewInt64Coin("uband", 50)), app.SupplyKeeper.GetModuleAccount(ctx, distribution.ModuleName).GetCoins())
 	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDec(1)}}, app.DistrKeeper.GetFeePool(ctx).CommunityPool)
-	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(4354, 2)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator1.ValAddress))
-	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(546, 2)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator2.ValAddress))
+	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(43015, 3)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator1.ValAddress))
+	require.Equal(t, sdk.DecCoins{{Denom: "uband", Amount: sdk.NewDecWithPrec(5985, 3)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, testapp.Validator2.ValAddress))
 }

--- a/chain/x/oracle/types/params.go
+++ b/chain/x/oracle/types/params.go
@@ -16,7 +16,7 @@ const (
 	DefaultBaseRequestGas          = uint64(150000)
 	DefaultPerValidatorRequestGas  = uint64(30000)
 	DefaultSamplingTryCount        = uint64(3)
-	DefaultOracleRewardPercentage  = uint64(80)
+	DefaultOracleRewardPercentage  = uint64(70)
 	DefaultInactivePenaltyDuration = uint64(10 * time.Minute)
 )
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
This PR update default genesis parameters for oracle reward percentage and block proposer rewards. Main reason being that we want to keep the incentive for block proposer to include as many signatures and take transactions with high fees. Note that this changes only the default genesis values. When spinning a chain, these values can be changed in genesis.json.

---

Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
