### PR TITLE
chain/yoda: Add commands for improve experience of starting yoda process

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,8 @@
 
 ### Chain (Non-consensus)
 
+- (impv)[\#2204](https://github.com/bandprotocol/bandchain/pull/2204) Add commands for improve experience of starting yoda process.
+
 ### Yoda
 
 - (feat) [\#2198](https://github.com/bandprotocol/bandchain/pull/2198) Implement POC docker executor.
@@ -60,4 +62,3 @@
 ### MISC
 
 - (impv) [\#2195](https://github.com/bandprotocol/bandchain/pull/2195) Remove lib and update executable as base64 encoded.
-

--- a/chain/cmd/bandcli/main.go
+++ b/chain/cmd/bandcli/main.go
@@ -107,6 +107,7 @@ func txCmd(cdc *amino.Codec) *cobra.Command {
 
 	txCmd.AddCommand(
 		bankcmd.SendTxCmd(cdc),
+		MultiSendTxCmd(cdc),
 		flags.LineBreak,
 		authcmd.GetSignCommand(cdc),
 		authcmd.GetMultiSignCommand(cdc),

--- a/chain/cmd/bandcli/multi_send.go
+++ b/chain/cmd/bandcli/multi_send.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/spf13/cobra"
+)
+
+func mulCoins(coins sdk.Coins, multiplier int64) sdk.Coins {
+	var newCoins sdk.Coins
+	for _, coin := range coins {
+		newCoins = append(newCoins, sdk.NewCoin(coin.Denom, coin.Amount.MulRaw(multiplier)))
+	}
+	return newCoins
+}
+
+// MultiSendTxCmd will create a multi-send tx and sign it with the given key.
+func MultiSendTxCmd(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "multi-send [amount] [to_address1] [to_address2] ....",
+		Short: "Create and sign a multi-send tx",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			// parse coins trying to be sent
+			coins, err := sdk.ParseCoins(args[0])
+			if err != nil {
+				return err
+			}
+			msg := bank.NewMsgMultiSend(
+				[]bank.Input{bank.NewInput(cliCtx.GetFromAddress(), mulCoins(coins, int64(len(args[1:]))))},
+				[]bank.Output{},
+			)
+			for _, arg := range args[1:] {
+				to, err := sdk.AccAddressFromBech32(arg)
+				if err != nil {
+					return err
+				}
+				msg.Outputs = append(msg.Outputs, bank.NewOutput(to, coins))
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+	cmd = flags.PostCommands(cmd)[0]
+	return cmd
+}

--- a/chain/docker-config/start_docker.sh
+++ b/chain/docker-config/start_docker.sh
@@ -133,21 +133,21 @@ do
 
     for i in $(eval echo {1..5})
     do
-    # add reporter key
-    yoda keys add reporter$i
+        # add reporter key
+        yoda keys add reporter$i
+    done
 
-    # send band tokens to reporter
-    echo "y" | bandcli tx send validator$v $(yoda keys show reporter$i) 1000000uband --keyring-backend test
+    # send band tokens to reporters
+    echo "y" | bandcli tx multi-send 1000000uband $(yoda keys list -a) --from $1 --keyring-backend test
 
     # wait for sending band tokens transaction success
     sleep 2
 
     # add reporter to bandchain
-    echo "y" | bandcli tx oracle add-reporter $(yoda keys show reporter$i) --from validator$v --keyring-backend test
+    echo "y" | bandcli tx oracle add-reporters $(yoda keys list -a) --from $1 --keyring-backend test
 
     # wait for addding reporter transaction success
     sleep 2
-    done
 
     docker create --network bandchain_bandchain --name bandchain_oracle${v} band-validator:latest yoda r
     docker cp ~/.yoda bandchain_oracle${v}:/root/.yoda

--- a/chain/scripts/start_yoda.sh
+++ b/chain/scripts/start_yoda.sh
@@ -9,7 +9,6 @@ yoda config chain-id bandchain
 yoda config validator $(bandcli keys show $1 -a --bech val --keyring-backend test)
 
 # setup execution endpoint
-# yoda config executor "rest:https://3hdt5gnbr6.execute-api.ap-southeast-1.amazonaws.com/live/py-execution"
 yoda config executor "docker:bandprotocol/runtime:1.0.1"
 
 echo "y" | bandcli tx oracle activate --from $1 --keyring-backend test
@@ -21,19 +20,19 @@ for i in $(eval echo {1..$2})
 do
   # add reporter key
   yoda keys add reporter$i
-
-  # send band tokens to reporter
-  echo "y" | bandcli tx send $1 $(yoda keys show reporter$i) 1000000uband --keyring-backend test
-
-  # wait for sending band tokens transaction success
-  sleep 2
-
-  # add reporter to bandchain
-  echo "y" | bandcli tx oracle add-reporter $(yoda keys show reporter$i) --from $1 --keyring-backend test
-
-  # wait for addding reporter transaction success
-  sleep 2
 done
+
+# send band tokens to reporters
+echo "y" | bandcli tx multi-send 1000000uband $(yoda keys list -a) --from $1 --keyring-backend test
+
+# wait for sending band tokens transaction success
+sleep 2
+
+# add reporter to bandchain
+echo "y" | bandcli tx oracle add-reporters $(yoda keys list -a) --from $1 --keyring-backend test
+
+# wait for addding reporter transaction success
+sleep 2
 
 # run yoda
 yoda run

--- a/chain/x/oracle/client/cli/tx.go
+++ b/chain/x/oracle/client/cli/tx.go
@@ -46,9 +46,8 @@ func GetTxCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
 		GetCmdEditOracleScript(cdc),
 		GetCmdRequest(cdc),
 		GetCmdActivate(cdc),
-		GetCmdAddReporter(cdc),
-		GetCmdRemoveReporter(cdc),
 		GetCmdAddReporters(cdc),
+		GetCmdRemoveReporter(cdc),
 	)...)
 
 	return oracleCmd
@@ -484,16 +483,16 @@ $ %s tx oracle activate --from mykey
 	return cmd
 }
 
-// GetCmdAddReporter implements the add reporter command handler.
-func GetCmdAddReporter(cdc *codec.Codec) *cobra.Command {
+// GetCmdAddReporters implements the add reporters command handler.
+func GetCmdAddReporters(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add-reporter [reporter]",
-		Short: "Add an agent authorized to submit report transactions.",
-		Args:  cobra.ExactArgs(1),
+		Use:   "add-reporters [reporter1] [reporter2] ...",
+		Short: "Add agents authorized to submit report transactions.",
+		Args:  cobra.MinimumNArgs(1),
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Add an agent authorized to submit report transactions.
+			fmt.Sprintf(`Add agents authorized to submit report transactions.
 Example:
-$ %s tx oracle add-reporter band1p40yh3zkmhcv0ecqp3mcazy83sa57rgjp07dun --from mykey
+$ %s tx oracle add-reporters band1p40yh3zkmhcv0ecqp3mcazy83sa57rgjp07dun band1m5lq9u533qaya4q3nfyl6ulzqkpkhge9q8tpzs --from mykey
 `,
 				version.ClientName,
 			),
@@ -504,19 +503,22 @@ $ %s tx oracle add-reporter band1p40yh3zkmhcv0ecqp3mcazy83sa57rgjp07dun --from m
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
 			validator := sdk.ValAddress(cliCtx.GetFromAddress())
-			reporter, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil {
-				return err
+			msgs := make([]sdk.Msg, len(args))
+			for i, raw := range args {
+				reporter, err := sdk.AccAddressFromBech32(raw)
+				if err != nil {
+					return err
+				}
+				msgs[i] = types.NewMsgAddReporter(
+					validator,
+					reporter,
+				)
+				err = msgs[i].ValidateBasic()
+				if err != nil {
+					return err
+				}
 			}
-			msg := types.NewMsgAddReporter(
-				validator,
-				reporter,
-			)
-			err = msg.ValidateBasic()
-			if err != nil {
-				return err
-			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgs)
 		},
 	}
 
@@ -555,48 +557,6 @@ $ %s tx oracle remove-reporter band1p40yh3zkmhcv0ecqp3mcazy83sa57rgjp07dun --fro
 				return err
 			}
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-		},
-	}
-
-	return cmd
-}
-
-// GetCmdAddReporter implements the add reporter command handler.
-func GetCmdAddReporters(cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "add-reporters [reporter1] [reporter2] ...",
-		Short: "Add an agent authorized to submit report transactions.",
-		Args:  cobra.MinimumNArgs(1),
-		Long: strings.TrimSpace(
-			fmt.Sprintf(`Add agents authorized to submit report transactions.
-Example:
-$ %s tx oracle add-reporters band1p40yh3zkmhcv0ecqp3mcazy83sa57rgjp07dun band1m5lq9u533qaya4q3nfyl6ulzqkpkhge9q8tpzs --from mykey
-`,
-				version.ClientName,
-			),
-		),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			validator := sdk.ValAddress(cliCtx.GetFromAddress())
-			msgs := make([]sdk.Msg, len(args))
-			for i, raw := range args {
-				reporter, err := sdk.AccAddressFromBech32(raw)
-				if err != nil {
-					return err
-				}
-				msgs[i] = types.NewMsgAddReporter(
-					validator,
-					reporter,
-				)
-				err = msgs[i].ValidateBasic()
-				if err != nil {
-					return err
-				}
-			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgs)
 		},
 	}
 

--- a/chain/yoda/keys.go
+++ b/chain/yoda/keys.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/go-bip39"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 	flagIndex    = "index"
 	flagCoinType = "coin-type"
 	flagRecover  = "recover"
+	flagAddress  = "address"
 )
 
 func keysCmd(c *Context) *cobra.Command {
@@ -135,12 +137,19 @@ func keysListCmd(c *Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			isShowAddr := viper.GetBool(flagAddress)
 			for _, key := range keys {
-				fmt.Printf("%s => %s\n", key.GetName(), key.GetAddress().String())
+				if isShowAddr {
+					fmt.Printf("%s ", key.GetAddress().String())
+				} else {
+					fmt.Printf("%s => %s\n", key.GetName(), key.GetAddress().String())
+				}
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolP(flagAddress, "a", false, "Output the address only")
+	viper.BindPFlag(flagAddress, cmd.Flags().Lookup(flagAddress))
 	return cmd
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
- Add `multi-send` command in the same level of send cmd to send coin from 1 account to multiple accounts with the same amount.
- Add `add-reporters` command to pack `MsgAddReport`s in one transaction.
- Add flag in `yoda keys list` to get only address using in `multi-send` and `add-reporters` command. Look example at `start_yoda.sh`.

Please ensure the following requirements are met before submitting a pull request:
---
- [x] The pull request is targeted against the correct target branch
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests. (Test by run chain can request and report correctly)
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
