### PR TITLE
yoda: Implement MultiExec to combine multiple executors

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,6 +14,7 @@
 
 ### Yoda
 
+- (feat) [\#2218](https://github.com/bandprotocol/bandchain/pull/2218) Implement MultiExec to combine multiple executors.
 - (feat) [\#2198](https://github.com/bandprotocol/bandchain/pull/2198) Implement POC docker executor.
 - (impv) [\#2197](https://github.com/bandprotocol/bandchain/pull/2197) Combine execution type to `rest` and update add ds or script.
 - (bugs) [\#2193](https://github.com/bandprotocol/bandchain/pull/2193) Fix bug start_docker.sh and start_yoda.sh.

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -15,10 +15,6 @@
 ### Yoda
 
 - (feat) [\#2218](https://github.com/bandprotocol/bandchain/pull/2218) Implement MultiExec to combine multiple executors.
-- (feat) [\#2198](https://github.com/bandprotocol/bandchain/pull/2198) Implement POC docker executor.
-- (impv) [\#2197](https://github.com/bandprotocol/bandchain/pull/2197) Combine execution type to `rest` and update add ds or script.
-- (bugs) [\#2193](https://github.com/bandprotocol/bandchain/pull/2193) Fix bug start_docker.sh and start_yoda.sh.
-- (feat) [\#2190](https://github.com/bandprotocol/bandchain/pull/2190) Add yoda command to bandchain.
 
 ### Emitter & Flusher
 

--- a/chain/yoda/executor/multi.go
+++ b/chain/yoda/executor/multi.go
@@ -1,0 +1,68 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// MutliExec is a higher-order executor that utlizes the underlying executors to perform Exec.
+type MultiExec struct {
+	execs    []Executor // The list of underlying executors.
+	strategy string     // Execution strategy. Can be "order" order "round-robin".
+	rIndex   int64      // Round-robin index, only applicable when strategy is "round-robin"
+}
+
+// MultiError encapsulates error messages from the underlying executors into one error.
+type MultiError struct {
+	errs []error
+}
+
+// NewMultiExec creates a new MultiExec instance.
+func NewMultiExec(execs []Executor, strategy string) (*MultiExec, error) {
+	if strategy != "order" && strategy != "round-robin" {
+		return &MultiExec{}, fmt.Errorf("unknown MultiExec strategy: %s", strategy)
+	}
+	return &MultiExec{execs: execs, strategy: strategy, rIndex: -1}, nil
+}
+
+// Error implements error interface for MultiError by returning all error messages concatenated.
+func (e *MultiError) Error() string {
+	var s strings.Builder
+	s.WriteString("MultiError: ")
+	for idx, each := range e.errs {
+		if idx != 0 {
+			s.WriteString(", ")
+		}
+		s.WriteString(each.Error())
+	}
+	return s.String()
+}
+
+// nextExecOrder returns the next order of executors to be used by MultiExec.
+func (e *MultiExec) nextExecOrder() []Executor {
+	switch e.strategy {
+	case "order":
+		return e.execs
+	case "round-robin":
+		rIndex := atomic.AddInt64(&e.rIndex, 1) % int64(len(e.execs))
+		return append(append([]Executor{}, e.execs[rIndex:]...), e.execs[:rIndex]...)
+	default:
+		panic("unknown MultiExec strategy") // We should never reach here.
+	}
+}
+
+// Exec implements Executor interface for MultiExec.
+func (e *MultiExec) Exec(timeout time.Duration, code []byte, arg string) (ExecResult, error) {
+	errs := []error{}
+	for _, each := range e.nextExecOrder() {
+		res, err := each.Exec(timeout, code, arg)
+		if err == nil || err == ErrExecutionimeout {
+			return res, err
+		} else {
+			errs = append(errs, err)
+		}
+	}
+	return ExecResult{}, &MultiError{errs: errs}
+}

--- a/chain/yoda/executor/multi_test.go
+++ b/chain/yoda/executor/multi_test.go
@@ -1,0 +1,106 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockExec struct {
+	called int
+	result ExecResult
+	err    error
+}
+
+func newMockExec(output []byte, code uint32, err error) *mockExec {
+	return &mockExec{
+		called: 0,
+		result: ExecResult{Output: output, Code: code},
+		err:    err,
+	}
+}
+
+func (e *mockExec) Exec(timeout time.Duration, code []byte, arg string) (ExecResult, error) {
+	e.called++
+	return e.result, e.err
+}
+
+func TestMultiExecOrderStrategy(t *testing.T) {
+	exec1 := newMockExec([]byte("output1"), 1, nil)
+	exec2 := newMockExec([]byte("output2"), 2, nil)
+	exec, err := NewMultiExec([]Executor{exec1, exec2}, "order")
+	require.NoError(t, err)
+	// Exec for the first time. Should go to exec1.
+	result, err := exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, result, ExecResult{Output: []byte("output1"), Code: 1})
+	require.Equal(t, 1, exec1.called)
+	require.Equal(t, 0, exec2.called)
+	// Doing it again. Should still go to exec1.
+	result, err = exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, result, ExecResult{Output: []byte("output1"), Code: 1})
+	require.Equal(t, 2, exec1.called)
+	require.Equal(t, 0, exec2.called)
+}
+
+func TestMultiExecRoundRobinStrategy(t *testing.T) {
+	exec1 := newMockExec([]byte("output1"), 1, nil)
+	exec2 := newMockExec([]byte("output2"), 2, nil)
+	exec, err := NewMultiExec([]Executor{exec1, exec2}, "round-robin")
+	require.NoError(t, err)
+	// Exec for the first time. Should go to exec1.
+	result, err := exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, result, ExecResult{Output: []byte("output1"), Code: 1})
+	require.Equal(t, 1, exec1.called)
+	require.Equal(t, 0, exec2.called)
+	// Doing it again. Should go to exec2.
+	result, err = exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, result, ExecResult{Output: []byte("output2"), Code: 2})
+	require.Equal(t, 1, exec1.called)
+	require.Equal(t, 1, exec2.called)
+	// Doing it again. Should go to exec1.
+	result, err = exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, result, ExecResult{Output: []byte("output1"), Code: 1})
+	require.Equal(t, 2, exec1.called)
+	require.Equal(t, 1, exec2.called)
+}
+
+func TestMultiExecBadStrategy(t *testing.T) {
+	_, err := NewMultiExec([]Executor{}, "bad")
+	require.EqualError(t, err, "unknown MultiExec strategy: bad")
+}
+
+func TestMultiExecOneWorking(t *testing.T) {
+	exec1 := newMockExec(nil, 0, errors.New("error1"))
+	exec2 := newMockExec([]byte("output"), 0, nil)
+	exec3 := newMockExec(nil, 0, errors.New("error3"))
+	exec, err := NewMultiExec([]Executor{exec1, exec2, exec3}, "round-robin")
+	result, err := exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, ExecResult{Output: []byte("output"), Code: 0}, result)
+	result, err = exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, ExecResult{Output: []byte("output"), Code: 0}, result)
+	result, err = exec.Exec(0, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, ExecResult{Output: []byte("output"), Code: 0}, result)
+}
+
+func TestMultiExecAllErrors(t *testing.T) {
+	exec1 := newMockExec(nil, 0, errors.New("error1"))
+	exec2 := newMockExec(nil, 0, errors.New("error2"))
+	exec3 := newMockExec(nil, 0, errors.New("error3"))
+	exec, err := NewMultiExec([]Executor{exec1, exec2, exec3}, "round-robin")
+	_, err = exec.Exec(0, nil, "")
+	require.EqualError(t, err, "MultiError: error1, error2, error3")
+	_, err = exec.Exec(0, nil, "")
+	require.EqualError(t, err, "MultiError: error2, error3, error1")
+	_, err = exec.Exec(0, nil, "")
+	require.EqualError(t, err, "MultiError: error3, error1, error2")
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
`MultiExec` is a higher-order level executor. It maintains a list of executors to be used. Whenever it's asked to perform `Exec`, it iterates through the list and calls `Exec` on each executor, returning the first one that does not return an error (note that timeout error does not count as error). 

`MultiExec` supports two strategies of looping. 
- `order` always loops in the initialize order
- `round-robin` rotates around the list to make sure all executors get used.

In the future, we may consider more sophisticated strategies like if one returns error, you may mark it as down and perform exponential backoffs, etc.

---

Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
