### PR TITLE
yoda: Use max data size configurations from oracle module

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -16,6 +16,7 @@
 
 ### Yoda
 
+- (impv) [\#2247](https://github.com/bandprotocol/bandchain/pull/2247) Use max data size configurations from oracle module
 - (feat) [\#2218](https://github.com/bandprotocol/bandchain/pull/2218) Implement MultiExec to combine multiple executors.
 
 ### Emitter & Flusher

--- a/chain/yoda/executor/docker.go
+++ b/chain/yoda/executor/docker.go
@@ -10,11 +10,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
 	"github.com/google/shlex"
 )
-
-// TODO: Make this configurable
-const MAX_OUTPUT_SIZE = 512
 
 type DockerExec struct {
 	image string
@@ -65,7 +63,7 @@ func (e *DockerExec) Exec(timeout time.Duration, code []byte, arg string) (ExecR
 			return ExecResult{}, nil
 		}
 	}
-	output, err := ioutil.ReadAll(io.LimitReader(&buf, MAX_OUTPUT_SIZE))
+	output, err := ioutil.ReadAll(io.LimitReader(&buf, types.MaxDataSize))
 	if err != nil {
 		return ExecResult{}, err
 	}

--- a/chain/yoda/executor/docker_test.go
+++ b/chain/yoda/executor/docker_test.go
@@ -38,3 +38,12 @@ func TestDockerSuccess(t *testing.T) {
 	// 	fmt.Println(string(res.Output), res.Code, err)
 	// require.True(t, false)
 }
+
+func TestDockerLongStdout(t *testing.T) {
+	// TODO: Enable test when CI has docker installed.
+	// 	e := NewDockerExec("bandprotocol/runtime:1.0.1")
+	// 	res, err := e.Exec(10*time.Second, []byte(`#!/usr/bin/env python3
+	// print("A"*1000)`), "BTC")
+	// 	fmt.Println(string(res.Output), res.Code, err)
+	// 	require.True(t, false)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
This PR changes docker executor to use max data size from the oracle module configuration. This ensures that there are no inconsistencies between yoda and chain.

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
