### PR TITLE
go-owasm: Allow OEI to read nil external data

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,8 @@
 
 ### Chain (Consensus)
 
+- (bugs) [\#2251](https://github.com/bandprotocol/bandchain/pull/2251)  go-owasm: Allow OEI to read nil external data
+
 ### Chain (Non-consensus)
 
 - (impv) [\#2232](https://github.com/bandprotocol/bandchain/pull/2218) CLI/REST for query active oracle validators.

--- a/chain/x/oracle/keeper/owasm_test.go
+++ b/chain/x/oracle/keeper/owasm_test.go
@@ -313,6 +313,53 @@ func TestResolveRequestSuccessComplex(t *testing.T) {
 	)}, ctx.EventManager().Events())
 }
 
+func TestResolveReadNilExternalData(t *testing.T) {
+	_, ctx, k := testapp.CreateTestInput(true)
+	ctx = ctx.WithBlockTime(testapp.ParseTime(1581589890))
+	k.SetRequest(ctx, 42, types.NewRequest(
+		// 4st Wasm. Append all reports from all validators.
+		4, obi.MustEncode(testapp.Wasm4Input{
+			IDs:      []int64{1, 2},
+			Calldata: string(BasicCalldata),
+		}), []sdk.ValAddress{testapp.Validator1.ValAddress, testapp.Validator2.ValAddress}, 1,
+		42, testapp.ParseTime(1581589790), BasicClientID, []types.RawRequest{
+			types.NewRawRequest(0, 1, BasicCalldata),
+			types.NewRawRequest(1, 2, BasicCalldata),
+		},
+	))
+	k.SetReport(ctx, 42, types.NewReport(
+		testapp.Validator1.ValAddress, true, []types.RawReport{
+			types.NewRawReport(0, 0, nil),
+			types.NewRawReport(1, 0, []byte("beebd2v1")),
+		},
+	))
+	k.SetReport(ctx, 42, types.NewReport(
+		testapp.Validator2.ValAddress, true, []types.RawReport{
+			types.NewRawReport(0, 0, []byte("beebd1v2")),
+			types.NewRawReport(1, 0, nil),
+		},
+	))
+	k.ResolveRequest(ctx, 42)
+	reqPacket := types.NewOracleRequestPacketData(
+		BasicClientID, 4, obi.MustEncode(testapp.Wasm4Input{
+			IDs:      []int64{1, 2},
+			Calldata: string(BasicCalldata),
+		}), 2, 1,
+	)
+	resPacket := types.NewOracleResponsePacketData(
+		BasicClientID, 42, 2, testapp.ParseTime(1581589790).Unix(),
+		testapp.ParseTime(1581589890).Unix(), types.ResolveStatus_Success,
+		obi.MustEncode(testapp.Wasm4Output{Ret: "beebd1v2beebd2v1"}),
+	)
+	require.Equal(t, types.NewResult(reqPacket, resPacket), k.MustGetResult(ctx, 42))
+	require.Equal(t, sdk.Events{sdk.NewEvent(
+		types.EventTypeResolve,
+		sdk.NewAttribute(types.AttributeKeyID, "42"),
+		sdk.NewAttribute(types.AttributeKeyResolveStatus, "1"),
+		sdk.NewAttribute(types.AttributeKeyResult, "0000001062656562643176326265656264327631"),
+	)}, ctx.EventManager().Events())
+}
+
 func TestResolveRequestNoReturnData(t *testing.T) {
 	_, ctx, k := testapp.CreateTestInput(true)
 	ctx = ctx.WithBlockTime(testapp.ParseTime(1581589890))

--- a/chain/x/oracle/keeper/owasm_test.go
+++ b/chain/x/oracle/keeper/owasm_test.go
@@ -270,7 +270,7 @@ func TestResolveRequestSuccessComplex(t *testing.T) {
 	_, ctx, k := testapp.CreateTestInput(true)
 	ctx = ctx.WithBlockTime(testapp.ParseTime(1581589890))
 	k.SetRequest(ctx, 42, types.NewRequest(
-		// 4st Wasm. Append all reports from all validators.
+		// 4th Wasm. Append all reports from all validators.
 		4, obi.MustEncode(testapp.Wasm4Input{
 			IDs:      []int64{1, 2},
 			Calldata: string(BasicCalldata),
@@ -317,7 +317,7 @@ func TestResolveReadNilExternalData(t *testing.T) {
 	_, ctx, k := testapp.CreateTestInput(true)
 	ctx = ctx.WithBlockTime(testapp.ParseTime(1581589890))
 	k.SetRequest(ctx, 42, types.NewRequest(
-		// 4st Wasm. Append all reports from all validators.
+		// 4th Wasm. Append all reports from all validators.
 		4, obi.MustEncode(testapp.Wasm4Input{
 			IDs:      []int64{1, 2},
 			Calldata: string(BasicCalldata),

--- a/go-owasm/api/env.go
+++ b/go-owasm/api/env.go
@@ -86,8 +86,5 @@ func cGetExternalData(e *C.env_t, eid C.int64_t, vid C.int64_t, data *C.Span) C.
 	if err != nil {
 		return toCError(err)
 	}
-	if extData == nil {
-		return C.Error_UnavailableExternalDataError
-	}
 	return writeSpan(data, extData)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
Allow Owasm script to read nil report data. This fixes a potential issue where a malicious validator may intentionally report `nil` data to make oracle request complete failure. With this change, the oracle script can decide what to do with empty data itself.

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
