### PR TITLE
hotfix: `handle_set_validator` get wrong validator id

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -21,6 +21,7 @@
 
 ### Emitter & Flusher
 
+- (bugs) [\#2252](https://github.com/bandprotocol/bandchain/pull/2252) `handle_set_validator` get wrong validator id.
 - (impv) [\#2250](https://github.com/bandprotocol/bandchain/pull/2250) Add account id in `validators` table.
 - (feat) [\#2246](https://github.com/bandprotocol/bandchain/pull/2246) Implement handle all resolve proposal status.
 - (feat) [\#2242](https://github.com/bandprotocol/bandchain/pull/2242) Implement handle MsgVote for emitter and flusher.

--- a/flusher/flusher/handler.py
+++ b/flusher/flusher/handler.py
@@ -128,7 +128,7 @@ class Handler(object):
     def handle_set_validator(self, msg):
         msg["account_id"] = self.get_account_id(msg["delegator_address"])
         del msg["delegator_address"]
-        if self.get_account_id(msg["operator_address"]) is None:
+        if self.get_validator_id(msg["operator_address"]) is None:
             self.conn.execute(validators.insert(), msg)
         else:
             condition = True


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


## Implementation details
- This makes `set_validator` try to create a new row because cannot find existed validator id. And fail on integrity constraint check.

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
