### PR TITLE
yoda: Increase default tx commit timeout

### DIFF
--- a/chain/yoda/context.go
+++ b/chain/yoda/context.go
@@ -20,5 +20,5 @@ type Context struct {
 	fileCache        filecache.Cache
 	broadcastTimeout time.Duration
 	maxTry           uint64
-	rpcPollIntervall time.Duration
+	rpcPollInterval  time.Duration
 }

--- a/chain/yoda/execute.go
+++ b/chain/yoda/execute.go
@@ -34,7 +34,7 @@ func SubmitReport(c *Context, l *Logger, key keys.Info, id otypes.RequestID, rep
 		acc, err := auth.NewAccountRetriever(cliCtx).GetAccount(key.GetAddress())
 		if err != nil {
 			l.Info(":warning: Failed to retreive account with error: %s", err.Error())
-			time.Sleep(c.rpcPollIntervall)
+			time.Sleep(c.rpcPollInterval)
 			continue
 		}
 
@@ -50,7 +50,7 @@ func SubmitReport(c *Context, l *Logger, key keys.Info, id otypes.RequestID, rep
 		out, err := txBldr.WithKeybase(keybase).BuildAndSign(key.GetName(), ckeys.DefaultKeyPass, []sdk.Msg{msg})
 		if err != nil {
 			l.Info(":warning: Failed to build tx with error: %s", err.Error())
-			time.Sleep(c.rpcPollIntervall)
+			time.Sleep(c.rpcPollInterval)
 			continue
 		}
 		res, err := cliCtx.BroadcastTxSync(out)
@@ -59,14 +59,14 @@ func SubmitReport(c *Context, l *Logger, key keys.Info, id otypes.RequestID, rep
 			break
 		}
 		l.Info(":warning: Failed to broadcast tx with error: %s", err.Error())
-		time.Sleep(c.rpcPollIntervall)
+		time.Sleep(c.rpcPollInterval)
 	}
 	if txHash == "" {
 		l.Error(":exploding_head: Cannot try to broadcast more than %d try", c.maxTry)
 		return
 	}
 	for start := time.Now(); time.Since(start) < c.broadcastTimeout; {
-		time.Sleep(c.rpcPollIntervall)
+		time.Sleep(c.rpcPollInterval)
 		txRes, err := utils.QueryTx(cliCtx, txHash)
 		if err != nil {
 			l.Debug(":warning: Failed to query tx with error: %s", err.Error())

--- a/chain/yoda/run.go
+++ b/chain/yoda/run.go
@@ -103,7 +103,7 @@ func runCmd(c *Context) *cobra.Command {
 				return err
 			}
 			c.maxTry = cfg.MaxTry
-			c.rpcPollIntervall, err = time.ParseDuration(cfg.RPCPollInterval)
+			c.rpcPollInterval, err = time.ParseDuration(cfg.RPCPollInterval)
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ func runCmd(c *Context) *cobra.Command {
 	cmd.Flags().String(flagExecutor, "", "executor name and url for executing the data source script")
 	cmd.Flags().String(flags.FlagGasPrices, "", "gas prices for report transaction")
 	cmd.Flags().String(flagLogLevel, "info", "set the logger level")
-	cmd.Flags().String(flagBroadcastTimeout, "30s", "The time that Yoda will wait for tx commit")
+	cmd.Flags().String(flagBroadcastTimeout, "5m", "The time that Yoda will wait for tx commit")
 	cmd.Flags().String(flagRPCPollInterval, "1s", "The duration of rpc poll interval")
 	cmd.Flags().Uint64(flagMaxTry, 5, "The maximum number of tries to submit a report transaction")
 	viper.BindPFlag(flags.FlagChainID, cmd.Flags().Lookup(flags.FlagChainID))


### PR DESCRIPTION
This PR increases the default timeout to ensure `yoda` waits longer. From testnet experiment, setting this value too low results in `yoda` giving up to soon and messing up nonce number.