### PR TITLE
chain: Perform report only block if notice pending report tx for too long

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,7 @@
 
 ### Chain (Non-consensus)
 
+- (feat) [\#2517](https://github.com/bandprotocol/bandchain/pull/2387) Switch to report only block if notice pending report for too long.
 - (impv) [\#2387](https://github.com/bandprotocol/bandchain/pull/2387) Implementation of allow free report transaction.
 
 ### Yoda

--- a/chain/go.mod
+++ b/chain/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/mux v1.7.4
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kyokomi/emoji v2.2.4+incompatible
 	github.com/levigross/grequests v0.0.0-20190908174114-253788527a1a
 	github.com/oasisprotocol/oasis-core/go v0.0.0-20200730171716-3be2b460b3ac

--- a/chain/x/oracle/ante/ante.go
+++ b/chain/x/oracle/ante/ante.go
@@ -1,17 +1,30 @@
 package ante
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/bandprotocol/bandchain/chain/x/oracle"
 	"github.com/bandprotocol/bandchain/chain/x/oracle/keeper"
 )
 
-func checkValidReportMsg(ctx sdk.Context, oracleKeeper oracle.Keeper, msg sdk.Msg) bool {
-	rep, ok := msg.(oracle.MsgReportData)
-	if !ok {
-		return false
+var (
+	repTxCount       *lru.Cache
+	nextRepOnlyBlock int64
+)
+
+func init() {
+	var err error
+	repTxCount, err = lru.New(20000)
+	if err != nil {
+		panic(err)
 	}
+}
+
+func checkValidReportMsg(ctx sdk.Context, oracleKeeper oracle.Keeper, rep oracle.MsgReportData) bool {
 	if !oracleKeeper.IsReporter(ctx, rep.Validator, rep.Reporter) {
 		return false
 	}
@@ -37,17 +50,35 @@ func checkValidReportMsg(ctx sdk.Context, oracleKeeper oracle.Keeper, msg sdk.Ms
 	return true
 }
 
-// NewFeelessReportsAnteHandler returns a new ante handler that waives minimum gas price requirement
-// if the incoming tx is a valid report transaction.
+// NewFeelessReportsAnteHandler returns a new ante handler that waives minimum gas price
+// requirement if the incoming tx is a valid report transaction.
 func NewFeelessReportsAnteHandler(ante sdk.AnteHandler, oracleKeeper oracle.Keeper) sdk.AnteHandler {
 	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
 		if ctx.IsCheckTx() && !simulate {
+			// TODO: Move this out of "FeelessReports" ante handler.
+			isRepOnlyBlock := ctx.BlockHeight() == nextRepOnlyBlock
 			isValidReportTx := true
 			for _, msg := range tx.GetMsgs() {
-				if !checkValidReportMsg(ctx, oracleKeeper, msg) {
+				rep, ok := msg.(oracle.MsgReportData)
+				if !ok || !checkValidReportMsg(ctx, oracleKeeper, rep) {
 					isValidReportTx = false
 					break
 				}
+				if !isRepOnlyBlock {
+					key := fmt.Sprintf("%s:%d", rep.Validator.String(), rep.RequestID)
+					val, ok := repTxCount.Get(key)
+					nextVal := 1
+					if ok {
+						nextVal = val.(int) + 1
+					}
+					repTxCount.Add(key, nextVal)
+					if nextVal > 5 {
+						nextRepOnlyBlock = ctx.BlockHeight() + 1
+					}
+				}
+			}
+			if isRepOnlyBlock && !isValidReportTx {
+				return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Block reserved for report txs")
 			}
 			if isValidReportTx {
 				minGas := ctx.MinGasPrices()

--- a/chain/x/oracle/ante/ante.go
+++ b/chain/x/oracle/ante/ante.go
@@ -72,7 +72,7 @@ func NewFeelessReportsAnteHandler(ante sdk.AnteHandler, oracleKeeper oracle.Keep
 						nextVal = val.(int) + 1
 					}
 					repTxCount.Add(key, nextVal)
-					if nextVal > 5 {
+					if nextVal > 20 {
 						nextRepOnlyBlock = ctx.BlockHeight() + 1
 					}
 				}


### PR DESCRIPTION
In order to ensure that report transactions can go through even under heavy congestion, this PR introduces an experimental concept of report only blocks to be tested in GuanYu testnet2.