### PR TITLE
yoda: Queued and combine report msgs to one transaction + Gas estimation on multi-report transaction

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,6 +14,8 @@
 
 ### Yoda
 
+- (impv) [\#2569](https://github.com/bandprotocol/bandchain/pull/2569) Queued and combine report msgs to one transaction
+
 ### Emitter & Flusher
 
 - (impv) [\#2549](https://github.com/bandprotocol/bandchain/pull/2549) Implemented `data_source_requests` table

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,7 +14,7 @@
 
 ### Yoda
 
-- (impv) [\#2569](https://github.com/bandprotocol/bandchain/pull/2569) Queued and combine report msgs to one transaction
+- (impv) [\#2569](https://github.com/bandprotocol/bandchain/pull/2569) Queued and combine report msgs to one transaction + Remove hard code gas used on report and add retry logic when transaction out of gas.
 
 ### Emitter & Flusher
 

--- a/chain/scripts/start_yoda.sh
+++ b/chain/scripts/start_yoda.sh
@@ -12,7 +12,7 @@ yoda config validator $(bandcli keys show $1 -a --bech val --keyring-backend tes
 yoda config executor "rest:https://iv3lgtv11a.execute-api.ap-southeast-1.amazonaws.com/live/master?timeout=10s"
 
 # setup broadcast-timeout to yoda config
-yoda config broadcast-timeout "30s"
+yoda config broadcast-timeout "5m"
 
 # setup rpc-poll-interval to yoda config
 yoda config rpc-poll-interval "1s"

--- a/chain/yoda/context.go
+++ b/chain/yoda/context.go
@@ -1,6 +1,7 @@
 package yoda
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
@@ -8,17 +9,34 @@ import (
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 
 	"github.com/bandprotocol/bandchain/chain/pkg/filecache"
+	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
 	"github.com/bandprotocol/bandchain/chain/yoda/executor"
 )
+
+type ReportMsgWithKey struct {
+	msg         types.MsgReportData
+	execVersion []string
+	keyIndex    int64
+}
 
 type Context struct {
 	client           rpcclient.Client
 	validator        sdk.ValAddress
 	gasPrices        sdk.DecCoins
-	keys             chan keys.Info
+	keys             []keys.Info
 	executor         executor.Executor
 	fileCache        filecache.Cache
 	broadcastTimeout time.Duration
 	maxTry           uint64
 	rpcPollInterval  time.Duration
+	maxReport        uint64
+
+	pendingMsgs chan ReportMsgWithKey
+	freeKeys    chan int64
+	keyIndex    int64
+}
+
+func (c *Context) getKeyIndex() int64 {
+	keyIndex := atomic.AddInt64(&c.keyIndex, 1) % int64(len(c.keys))
+	return keyIndex
 }

--- a/chain/yoda/context.go
+++ b/chain/yoda/context.go
@@ -31,12 +31,12 @@ type Context struct {
 	rpcPollInterval  time.Duration
 	maxReport        uint64
 
-	pendingMsgs chan ReportMsgWithKey
-	freeKeys    chan int64
-	keyIndex    int64
+	pendingMsgs        chan ReportMsgWithKey
+	freeKeys           chan int64
+	keyRoundRobinIndex int64 // Must use in conjunction with sync/atomic
 }
 
-func (c *Context) getKeyIndex() int64 {
-	keyIndex := atomic.AddInt64(&c.keyIndex, 1) % int64(len(c.keys))
+func (c *Context) nextKeyIndex() int64 {
+	keyIndex := atomic.AddInt64(&c.keyRoundRobinIndex, 1) % int64(len(c.keys))
 	return keyIndex
 }

--- a/chain/yoda/event.go
+++ b/chain/yoda/event.go
@@ -4,23 +4,24 @@ import (
 	"fmt"
 	"strconv"
 
-	otypes "github.com/bandprotocol/bandchain/chain/x/oracle/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/bandprotocol/bandchain/chain/x/oracle/types"
 )
 
 type rawRequest struct {
-	dataSourceID   otypes.DataSourceID
+	dataSourceID   types.DataSourceID
 	dataSourceHash string
-	externalID     otypes.ExternalID
+	externalID     types.ExternalID
 	calldata       string
 }
 
 // GetRawRequests returns the list of all raw data requests in the given log.
 func GetRawRequests(log sdk.ABCIMessageLog) ([]rawRequest, error) {
-	dataSourceIDs := GetEventValues(log, otypes.EventTypeRawRequest, otypes.AttributeKeyDataSourceID)
-	dataSourceHashList := GetEventValues(log, otypes.EventTypeRawRequest, otypes.AttributeKeyDataSourceHash)
-	externalIDs := GetEventValues(log, otypes.EventTypeRawRequest, otypes.AttributeKeyExternalID)
-	calldataList := GetEventValues(log, otypes.EventTypeRawRequest, otypes.AttributeKeyCalldata)
+	dataSourceIDs := GetEventValues(log, types.EventTypeRawRequest, types.AttributeKeyDataSourceID)
+	dataSourceHashList := GetEventValues(log, types.EventTypeRawRequest, types.AttributeKeyDataSourceHash)
+	externalIDs := GetEventValues(log, types.EventTypeRawRequest, types.AttributeKeyExternalID)
+	calldataList := GetEventValues(log, types.EventTypeRawRequest, types.AttributeKeyCalldata)
 
 	if len(dataSourceIDs) != len(externalIDs) {
 		return nil, fmt.Errorf("Inconsistent data source count and external ID count")
@@ -42,9 +43,9 @@ func GetRawRequests(log sdk.ABCIMessageLog) ([]rawRequest, error) {
 		}
 
 		reqs = append(reqs, rawRequest{
-			dataSourceID:   otypes.DataSourceID(dataSourceID),
+			dataSourceID:   types.DataSourceID(dataSourceID),
 			dataSourceHash: dataSourceHashList[idx],
-			externalID:     otypes.ExternalID(externalID),
+			externalID:     types.ExternalID(externalID),
 			calldata:       calldataList[idx],
 		})
 	}

--- a/chain/yoda/execute.go
+++ b/chain/yoda/execute.go
@@ -22,7 +22,7 @@ var (
 )
 
 func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWithKey) {
-	// Return key when sending transaction successfully
+	// Return key when done with SubmitReport whether successfully or not.
 	defer func() {
 		c.freeKeys <- keyIndex
 	}()
@@ -49,7 +49,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 	for exec := range versionMap {
 		versions = append(versions, exec)
 	}
-	memo := strings.Join(versions, ",")
+	executorVersion := strings.Join(versions, ",")
 	key := c.keys[keyIndex]
 	cliCtx := sdkCtx.CLIContext{Client: c.client, TrustNode: true, Codec: cdc}
 	txHash := ""
@@ -64,7 +64,7 @@ func SubmitReport(c *Context, l *Logger, keyIndex int64, reports []ReportMsgWith
 
 		txBldr := auth.NewTxBuilder(
 			auth.DefaultTxEncoder(cdc), acc.GetAccountNumber(), acc.GetSequence(),
-			200000, 1, false, cfg.ChainID, fmt.Sprintf("yoda:%s/exec:%s", version.Version, memo), sdk.NewCoins(), c.gasPrices,
+			200000, 1, false, cfg.ChainID, fmt.Sprintf("yoda:%s/exec:%s", version.Version, executorVersion), sdk.NewCoins(), c.gasPrices,
 		)
 		// txBldr, err = authclient.EnrichWithGas(txBldr, cliCtx, []sdk.Msg{msg})
 		// if err != nil {

--- a/chain/yoda/execute.go
+++ b/chain/yoda/execute.go
@@ -36,7 +36,7 @@ var (
 const (
 	dataSizeMultiplier    = uint64(50)
 	msgReportDataConstant = uint64(16000)
-	txSizeConstant        = uint64(10) // Using DefaultTxSizeCostPerByte
+	txSizeConstant        = uint64(5) // Using DefaultTxSizeCostPerByte of BandChain
 	baseTransaction       = uint64(40000)
 	pendingRequests       = uint64(4000)
 )

--- a/chain/yoda/handler.go
+++ b/chain/yoda/handler.go
@@ -85,7 +85,7 @@ func handleRequestLog(c *Context, l *Logger, log sdk.ABCIMessageLog) {
 		l.Error(":skull: Failed to parse raw requests with error: %s", err.Error())
 	}
 
-	keyIndex := c.getKeyIndex()
+	keyIndex := c.nextKeyIndex()
 	key := c.keys[keyIndex]
 
 	reportsChan := make(chan types.RawReport, len(reqs))

--- a/chain/yoda/main.go
+++ b/chain/yoda/main.go
@@ -22,6 +22,7 @@ const (
 	flagBroadcastTimeout = "broadcast-timeout"
 	flagRPCPollInterval  = "rpc-poll-interval"
 	flagMaxTry           = "max-try"
+	flagMaxReport        = "max-report"
 )
 
 // Config data structure for yoda daemon.
@@ -35,6 +36,7 @@ type Config struct {
 	BroadcastTimeout string `mapstructure:"broadcast-timeout"` // The time that Yoda will wait for tx commit
 	RPCPollInterval  string `mapstructure:"rpc-poll-interval"` // The duration of rpc poll interval
 	MaxTry           uint64 `mapstructure:"max-try"`           // The maximum number of tries to submit a report transaction
+	MaxReport        uint64 `mapstructure:"max-report"`        // The maximum number of reports in one transaction
 }
 
 // Global instances.

--- a/chain/yoda/run.go
+++ b/chain/yoda/run.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	keyring "github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,10 +41,36 @@ func runImpl(c *Context, l *Logger) error {
 		return err
 	}
 
+	availiableKeys := make([]bool, len(c.keys))
+	waitingMsgs := make([][]ReportMsgWithKey, len(c.keys))
+	for i := range availiableKeys {
+		availiableKeys[i] = true
+		waitingMsgs[i] = []ReportMsgWithKey{}
+	}
+
 	for {
 		select {
 		case ev := <-eventChan:
 			go handleTransaction(c, l, ev.Data.(tmtypes.EventDataTx).TxResult)
+		case keyIndex := <-c.freeKeys:
+			if len(waitingMsgs[keyIndex]) != 0 {
+				if uint64(len(waitingMsgs[keyIndex])) > c.maxReport {
+					go SubmitReport(c, l, keyIndex, waitingMsgs[keyIndex][:c.maxReport])
+					waitingMsgs[keyIndex] = waitingMsgs[keyIndex][c.maxReport:]
+				} else {
+					go SubmitReport(c, l, keyIndex, waitingMsgs[keyIndex])
+					waitingMsgs[keyIndex] = []ReportMsgWithKey{}
+				}
+			} else {
+				availiableKeys[keyIndex] = true
+			}
+		case pm := <-c.pendingMsgs:
+			if availiableKeys[pm.keyIndex] {
+				availiableKeys[pm.keyIndex] = false
+				go SubmitReport(c, l, pm.keyIndex, []ReportMsgWithKey{pm})
+			} else {
+				waitingMsgs[pm.keyIndex] = append(waitingMsgs[pm.keyIndex], pm)
+			}
 		}
 	}
 }
@@ -67,10 +92,7 @@ func runCmd(c *Context) *cobra.Command {
 			if len(keys) == 0 {
 				return errors.New("No key available")
 			}
-			c.keys = make(chan keyring.Info, len(keys))
-			for _, key := range keys {
-				c.keys <- key
-			}
+			c.keys = keys
 			c.validator, err = sdk.ValAddressFromBech32(cfg.Validator)
 			if err != nil {
 				return err
@@ -103,10 +125,14 @@ func runCmd(c *Context) *cobra.Command {
 				return err
 			}
 			c.maxTry = cfg.MaxTry
+			c.maxReport = cfg.MaxReport
 			c.rpcPollInterval, err = time.ParseDuration(cfg.RPCPollInterval)
 			if err != nil {
 				return err
 			}
+			c.pendingMsgs = make(chan ReportMsgWithKey, 0)
+			c.freeKeys = make(chan int64, len(keys))
+			c.keyIndex = -1
 			return runImpl(c, l)
 		},
 	}
@@ -119,6 +145,7 @@ func runCmd(c *Context) *cobra.Command {
 	cmd.Flags().String(flagBroadcastTimeout, "5m", "The time that Yoda will wait for tx commit")
 	cmd.Flags().String(flagRPCPollInterval, "1s", "The duration of rpc poll interval")
 	cmd.Flags().Uint64(flagMaxTry, 5, "The maximum number of tries to submit a report transaction")
+	cmd.Flags().Uint64(flagMaxReport, 10, "The maximum number of reports in one transaction")
 	viper.BindPFlag(flags.FlagChainID, cmd.Flags().Lookup(flags.FlagChainID))
 	viper.BindPFlag(flags.FlagNode, cmd.Flags().Lookup(flags.FlagNode))
 	viper.BindPFlag(flagValidator, cmd.Flags().Lookup(flagValidator))
@@ -128,5 +155,6 @@ func runCmd(c *Context) *cobra.Command {
 	viper.BindPFlag(flagBroadcastTimeout, cmd.Flags().Lookup(flagBroadcastTimeout))
 	viper.BindPFlag(flagRPCPollInterval, cmd.Flags().Lookup(flagRPCPollInterval))
 	viper.BindPFlag(flagMaxTry, cmd.Flags().Lookup(flagMaxTry))
+	viper.BindPFlag(flagMaxReport, cmd.Flags().Lookup(flagMaxReport))
 	return cmd
 }

--- a/chain/yoda/run.go
+++ b/chain/yoda/run.go
@@ -130,7 +130,7 @@ func runCmd(c *Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			c.pendingMsgs = make(chan ReportMsgWithKey, 0)
+			c.pendingMsgs = make(chan ReportMsgWithKey)
 			c.freeKeys = make(chan int64, len(keys))
 			c.keyRoundRobinIndex = -1
 			return runImpl(c, l)

--- a/chain/yoda/run.go
+++ b/chain/yoda/run.go
@@ -132,7 +132,7 @@ func runCmd(c *Context) *cobra.Command {
 			}
 			c.pendingMsgs = make(chan ReportMsgWithKey, 0)
 			c.freeKeys = make(chan int64, len(keys))
-			c.keyIndex = -1
+			c.keyRoundRobinIndex = -1
 			return runImpl(c, l)
 		},
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
- Not locking key when querying data sources.
- After report msg ready to be sent, it will be queued if the reporter key is pending on the latest sending transaction.
- When the reporter key is ready, it will pack reports msgs and send in one transaction.
- Add gas estimation on multi-reports msg transaction.
- Add retry logic when the report transaction out of gas

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
