### PR TITLE
yoda: Check timeout error from request

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -16,7 +16,7 @@
 
 ### Yoda
 
-- (impv) [\#2631](https://github.com/bandprotocol/bandchain/pull/2631) Add request timeout for each data source execution
+- (impv) [\#2638](https://github.com/bandprotocol/bandchain/pull/2631) Check timeout error from request + [\#2631](https://github.com/bandprotocol/bandchain/pull/2631) Add request timeout for each data source execution
 
 ### Emitter & Flusher
 

--- a/chain/yoda/executor/rest.go
+++ b/chain/yoda/executor/rest.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"encoding/base64"
+	"net/url"
 	"time"
 
 	"github.com/levigross/grequests"
@@ -42,7 +43,12 @@ func (e *RestExec) Exec(code []byte, arg string, env interface{}) (ExecResult, e
 	)
 
 	if err != nil {
-		return ExecResult{}, err
+		urlErr, ok := err.(*url.Error)
+		if !ok || !urlErr.Timeout() {
+			return ExecResult{}, err
+		}
+		// Return timeout code
+		return ExecResult{Output: []byte{}, Code: 111}, nil
 	}
 
 	if resp.Ok != true {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
It will report with 111 exit code instead of 255 when request timeout.

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
