### PR TITLE
chain: modify max block gas and bytes on migrate command

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,8 @@
 
 ### Chain (Non-consensus)
 
+- (impv) [\#2646](https://github.com/bandprotocol/bandchain/pull/2646) Modify max block gas and bytes on migrate command
+
 ### Yoda
 
 ### Emitter & Flusher

--- a/chain/cmd/bandd/migrate.go
+++ b/chain/cmd/bandd/migrate.go
@@ -41,6 +41,9 @@ func GenesisDocFromFile(genDocFile string, cdc *codec.Codec) (*tmtypes.GenesisDo
 
 	// Set up Tendermint consensus params with default value.
 	genDoc.ConsensusParams.Evidence = tmtypes.DefaultEvidenceParams()
+	genDoc.ConsensusParams.Block.MaxBytes = 1000000 // 1M bytes
+	genDoc.ConsensusParams.Block.MaxGas = 5000000   // 5M gas
+	genDoc.ConsensusParams.Block.TimeIotaMs = 1000  // 1 second
 
 	if err := genDoc.ValidateAndComplete(); err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Implementation details
From Wenchang to Guanyu, we increase block gas and block size for deploy oracle script to chain, and increase the throughput of the system. Therefore we need to modify wenchang consensus param when migration.

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
