### PR TITLE
pyband: use string instead of class annotation for Python3.6

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,6 +31,7 @@
 
 ### Helpers
 
+- (impv) [\#2652](https://github.com/bandprotocol/bandchain/pull/2652) pyband: use string instead of class annotation for Python3.6
 - (bugs) [\#2651](https://github.com/bandprotocol/bandchain/pull/2651) pyband: fix bug get latest block
 
 ### MISC

--- a/helpers/pyband/main.py
+++ b/helpers/pyband/main.py
@@ -1,4 +1,5 @@
 from pyband import Client, PyObi
+from pyband.wallet import PrivateKey
 
 
 def main():
@@ -9,6 +10,9 @@ def main():
     oracle_script = c.get_oracle_script(6)
     obi = PyObi(oracle_script.schema)
     print(obi.decode_output(req_info.result.response_packet_data.result))
+
+    _, priv = PrivateKey.generate()
+    print(priv.to_pubkey().to_acc_bech32(), priv.to_pubkey().to_address().to_acc_bech32())
 
 
 if __name__ == "__main__":

--- a/helpers/pyband/pyband/wallet.py
+++ b/helpers/pyband/pyband/wallet.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import hashlib
 
 from bech32 import bech32_encode, bech32_decode, convertbits
@@ -34,7 +32,7 @@ class PrivateKey:
         self.signing_key = None
 
     @classmethod
-    def generate(cls, path=DEFAULT_DERIVATION_PATH) -> (str, PrivateKey):
+    def generate(cls, path=DEFAULT_DERIVATION_PATH) -> (str, "PrivateKey"):
         """
         Generate new private key with random mnemonic phrase
 
@@ -50,7 +48,7 @@ class PrivateKey:
                 pass
 
     @classmethod
-    def from_mnemonic(cls, words: str, path="m/44'/494'/0'/0/0") -> PrivateKey:
+    def from_mnemonic(cls, words: str, path="m/44'/494'/0'/0/0") -> "PrivateKey":
         """
         Create a PrivateKey instance from a given mnemonic phrase and a HD derivation path.
         If path is not given, default to Band's HD prefix 494 and all other indexes being zeroes.
@@ -70,7 +68,7 @@ class PrivateKey:
         return self
 
     @classmethod
-    def from_hex(cls, priv: str) -> PrivateKey:
+    def from_hex(cls, priv: str) -> "PrivateKey":
         self = cls(_error_do_not_use_init_directly=True)
         self.signing_key = SigningKey.from_string(
             bytes.fromhex(priv), curve=SECP256k1, hashfunc=hashlib.sha256,
@@ -83,7 +81,7 @@ class PrivateKey:
         """
         return self.signing_key.to_string().hex()
 
-    def to_pubkey(self) -> PublicKey:
+    def to_pubkey(self) -> "PublicKey":
         """
         Return the PublicKey associated with this private key.
 
@@ -122,7 +120,7 @@ class PublicKey:
         self.verify_key = None
 
     @classmethod
-    def _from_bech32(cls, bech: str, prefix: str) -> PublicKey:
+    def _from_bech32(cls, bech: str, prefix: str) -> "PublicKey":
         hrp, bz = bech32_decode(bech)
         assert hrp == prefix, "Invalid bech32 prefix"
         bz = convertbits(bz, 5, 8, False)
@@ -133,15 +131,15 @@ class PublicKey:
         return self
 
     @classmethod
-    def from_acc_bech32(cls, bech: str) -> PublicKey:
+    def from_acc_bech32(cls, bech: str) -> "PublicKey":
         return cls._from_bech32(bech, BECH32_PUBKEY_ACC_PREFIX)
 
     @classmethod
-    def from_val_bech32(cls, bech: str) -> PublicKey:
+    def from_val_bech32(cls, bech: str) -> "PublicKey":
         return cls._from_bech32(bech, BECH32_PUBKEY_VAL_PREFIX)
 
     @classmethod
-    def from_cons_bech32(cls, bech: str) -> PublicKey:
+    def from_cons_bech32(cls, bech: str) -> "PublicKey":
         return cls._from_bech32(bech, BECH32_PUBKEY_CONS_PREFIX)
 
     def to_hex(self) -> str:
@@ -172,7 +170,7 @@ class PublicKey:
         """Return bech32-encoded with validator consensus public key prefix"""
         return self._to_bech32(BECH32_PUBKEY_CONS_PREFIX)
 
-    def to_address(self) -> Address:
+    def to_address(self) -> "Address":
         """Return address instance from this public key"""
         hash = hashlib.new("sha256", self.verify_key.to_string("compressed")).digest()
         return Address(hashlib.new("ripemd160", hash).digest())
@@ -198,23 +196,23 @@ class Address:
         self.addr = addr
 
     @classmethod
-    def _from_bech32(cls, bech: str, prefix: str) -> Address:
+    def _from_bech32(cls, bech: str, prefix: str) -> "Address":
         hrp, bz = bech32_decode(bech)
         assert hrp == prefix, "Invalid bech32 prefix"
         return cls(bytes(convertbits(bz, 5, 8, False)))
 
     @classmethod
-    def from_acc_bech32(cls, bech: str) -> Address:
+    def from_acc_bech32(cls, bech: str) -> "Address":
         """Create an address instance from a bech32-encoded account address"""
         return cls._from_bech32(bech, BECH32_ADDR_ACC_PREFIX)
 
     @classmethod
-    def from_val_bech32(cls, bech: str) -> Address:
+    def from_val_bech32(cls, bech: str) -> "Address":
         """Create an address instance from a bech32-encoded validator address"""
         return cls._from_bech32(bech, BECH32_ADDR_VAL_PREFIX)
 
     @classmethod
-    def from_cons_bech32(cls, bech: str) -> Address:
+    def from_cons_bech32(cls, bech: str) -> "Address":
         """Create an address instance from a bech32-encoded consensus address"""
         return cls._from_bech32(bech, BECH32_ADDR_CONS_PREFIX)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fixed: #2645 

## Implementation details
The type annotation of class will work on Python 4.0 (and _future__ in 3.7), but it doesn't work with Python3.6. Therefore we using a string of type instead class that work well on Python3.6.

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [x] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
