### PR TITLE
chain: Add Content-Type header on oracle module rest endpoints

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,7 @@
 
 ### Chain (Non-consensus)
 
+- (bugs) [\#2730](https://github.com/bandprotocol/bandchain/pull/2730) Add Content-Type header on oracle module rest endpoints
 - (feat) [\#2718](https://github.com/bandprotocol/bandchain/pull/2718) Added more field in price cache
 - (feat) [\#2694](https://github.com/bandprotocol/bandchain/pull/2694) Added pricer to cache latest price
 - (feat) [\#2690](https://github.com/bandprotocol/bandchain/pull/2690) Added `multi_request_search`endpoint

--- a/chain/x/oracle/client/common/helper.go
+++ b/chain/x/oracle/client/common/helper.go
@@ -15,6 +15,7 @@ func PostProcessQueryResponse(w http.ResponseWriter, cliCtx context.CLIContext, 
 	if err := json.Unmarshal(bz, &result); err != nil {
 		rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 	}
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(result.Status)
 	rest.PostProcessResponse(w, cliCtx, result.Result)
 }


### PR DESCRIPTION
Set content type header before write header.