### PR TITLE
Fix CI fail while setting up go

### DIFF
--- a/.github/workflows/chain.yaml
+++ b/.github/workflows/chain.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-go@v2-beta
         with:
           go-version: "1.14.7"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Install Wabt (wat2wasm)
         run: |

--- a/.github/workflows/chain.yaml
+++ b/.github/workflows/chain.yaml
@@ -12,11 +12,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2
         with:
           go-version: "1.14.7"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Install Wabt (wat2wasm)
         run: |

--- a/.github/workflows/go-owasm.yaml
+++ b/.github/workflows/go-owasm.yaml
@@ -18,11 +18,9 @@ jobs:
           override: true
 
       - name: Install Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2
         with:
           go-version: "^1.14.4"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Install Wabt (wat2wasm)
         run: |

--- a/.github/workflows/go-owasm.yaml
+++ b/.github/workflows/go-owasm.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-go@v2-beta
         with:
           go-version: "^1.14.4"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Install Wabt (wat2wasm)
         run: |


### PR DESCRIPTION
## Issue
- Github Actions fails while setting up go https://github.com/bandprotocol/bandchain/pull/2857/checks?check_run_id=1410284166

## Implementation details
- ~~Add flag `ACTIONS_ALLOW_UNSECURE_COMMANDS` to allow `actions/setup-go@v2-beta` to use `set-env`~~
- Upgrade to v2

## Please ensure the following requirements are met before submitting a pull request:

- [x] The pull request is targeted against the correct target branch
- [x] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [x] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [x] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
